### PR TITLE
fix: 日内回填分页深度算成了切片宽度，导致早期切片静默返回 0 行

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ the project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **A backfilled intraday slice near the historical edge silently returned
+  zero rows for every symbol, for no reason the logs could explain.**
+  `capture_intraday_bars` bounded the page walk (`max_pages`) by the trading
+  days *within* the requested slice (`end - start`), but the wire always pages
+  backward from the live tip (offset 0 = today), regardless of what `end` is.
+  For a slice sitting near the source's historical horizon, every page landed
+  more recent than `end`, got discarded by the date filter, and the walk gave
+  up at `max_pages` long before ever reaching the requested dates — an
+  8-trading-day-wide slice ~140 days back got `max_pages=4` and returned 0
+  rows; the depth actually needed was ~98 trading days, `max_pages=31`.
+
+  No exception, no partial data — just silence indistinguishable from "the
+  source has nothing here," on every symbol, at any scope, deterministically.
+  Found chasing what looked like TDX degrading under sustained full-market
+  load; a raw wire probe against the same window, run directly, returned real
+  data instantly, which ruled that out and pointed at the pagination bound
+  instead. `max_pages` now sizes off `trade_date -> start` (the real walk
+  depth) rather than `end -> start` (the slice's own width); the daily
+  incremental path is unaffected since its `end` already equals `trade_date`.
+
 - **`m2_yoy` held M0 month-over-month growth, not M2 year-on-year.** The AkShare
   path picked its value column by Chinese-substring match with a
   `next(..., columns[-1])` default. The hint `"M2-同比增长"` never matched the

--- a/src/ashare_lake/steps/intraday.py
+++ b/src/ashare_lake/steps/intraday.py
@@ -165,7 +165,17 @@ def capture_intraday_bars(
     # Bound the page walk: without it, every symbol is paged back to its full
     # retention depth and the extra pages are then discarded by the window
     # filter — 29 requests where 1 would do on the daily path.
-    trading_days = max(1, _approx_trading_days(config, start, end))
+    #
+    # The depth is trade_date -> start, NOT end -> start. The wire always pages
+    # back from the live tip (offset 0 = today), regardless of what `end` is,
+    # so a backfill slice near the historical edge still has to walk through
+    # everything between today and its start before reaching it — a shallow
+    # 10-day-wide slice sitting 140 days back needs ~30 pages, not ~4. Using
+    # the slice's own width here made every page land after `end`, get
+    # discarded by the date filter, and every symbol come back with zero rows
+    # — silently, with no error, indistinguishable from "TDX has nothing here"
+    # until traced back to a raw wire probe.
+    trading_days = max(1, _approx_trading_days(config, start, trade_date))
     max_pages = pages_for_window(frequency, trading_days)
 
     logger.info(

--- a/tests/unit/test_minute_bars_step.py
+++ b/tests/unit/test_minute_bars_step.py
@@ -397,3 +397,42 @@ def test_all_batches_failing_still_raises(cfg, monkeypatch):
         capture_intraday_bars(
             cfg, date(2026, 7, 31), "run-1", dataset="minute_bars", frequency="1m"
         )
+
+
+def test_max_pages_covers_the_walk_back_from_today_not_just_the_slice_width(cfg, monkeypatch):
+    """A chunked backfill slice deep in the past needs a deep page walk.
+
+    The wire always pages back from the live tip (offset 0 = today), not from
+    the slice's own `end`. Bounding max_pages by the slice's width (trading
+    days *within* [start, end]) starves a slice sitting near the historical
+    edge: every page it is allowed lands after `end`, gets discarded by the
+    date filter, and the symbol comes back with zero rows -- silently, with
+    no error, indistinguishable from "nothing there" until traced back to a
+    raw probe. Reproduced live against TDX before this fix: an 8-trading-day
+    slice starting ~140 days back got max_pages=4 (from the slice's own
+    width) and returned 0 rows; the correct depth (~98 trading days back to
+    trade_date) needs max_pages=31 and returns the real data.
+    """
+    cfg.minute_bars_enabled = True
+    cfg.minute_bars_scope = "watchlist"
+    cfg.minute_bars_symbols = ["600519.SH"]
+    cfg._backfill = True
+    # A 10-day-wide slice, but its END is ~140 days before trade_date -- the
+    # shape of the oldest chunk in a `_backfill_chunked` sweep.
+    cfg._backfill_start = date(2026, 3, 11)
+    cfg._backfill_end = date(2026, 3, 20)
+    trade_date = date(2026, 8, 1)
+
+    seen: dict = {}
+
+    def fetch(symbols, start, end, *, max_pages, **kwargs):
+        seen["max_pages"] = max_pages
+        return _fake_fetch()(symbols, start, end, **kwargs)
+
+    monkeypatch.setattr(intraday, "fetch_minute_bars", fetch)
+    capture_intraday_bars(cfg, trade_date, "run-1", dataset="minute_bars", frequency="1m")
+
+    # ~98 trading days (2026-03-11 -> 2026-08-01) at 240 bars/day needs ~30
+    # pages of 800; the slice's own width (8 trading days) would give 4 --
+    # enough to reach nowhere near the real window.
+    assert seen["max_pages"] >= 25


### PR DESCRIPTION
跟进 #7（`feat/minute-bars`）合并后的一次真实回填验证暴露出的 bug。

## 症状

全市场种子第二次尝试（`fetch_workers=1` + 连接重试/批级容错修复之后）在跑了约 3 小时后，**7,747 个标的全部返回零行**，没有任何异常。之后收窄到 CSI300（300 只）验证，同样的模式在约 4.5 分钟内复现——这打掉了"TDX 在长时间高负载下降级"的假设：如果是持续负载导致的限流，300 只、几分钟就该没事。

直接对同一个时间窗口做裸连接探测（绕开整条 pipeline），立刻拿到真实数据——证明服务端没有限流也没有拒绝。

## 根因

`capture_intraday_bars` 用「目标切片自身有多宽」（`end - start` 的交易日数）来限制翻页深度 `max_pages`。但 TDX 分页协议**永远从当下最新的那一页往回翻**（`offset=0` 恒等于"今天"），跟 `end` 是过去哪一天完全无关。

对一个靠近历史视野边缘的切片（比如全市场种子最早的那个 10 天分片），真正需要的是"从今天翻回到 `start` 要翻多少页"，而不是"`start` 到 `end` 之间有多少交易日"。用错误的窄口径算出来的 `max_pages` 只够翻到最近几天，每一页都比 `end` 新，全部被日期过滤器滤掉，还没翻到目标窗口就把翻页额度用完——**每个标的都返回 0 行，没有报错，跟"这里真的没数据"完全无法区分**。

实测：`2026-03-11..2026-03-20` 这个切片，按切片宽度算 `max_pages=4`，返回 0 行；按正确的深度算需要 `max_pages=31`，返回 1200 行。

## 修复

`max_pages` 现在用 `trade_date -> start`（真正的翻页深度）而不是 `end -> start`（切片宽度）来算。日更增量路径的 `end` 本来就等于 `trade_date`，所以这里改动对它是无操作——只有 `end` 落在过去的回填切片才会受影响，而这恰恰是唯一会触发这个 bug 的场景。

## 验证

- 直接对真实数据源复现并验证修复（0 行 → 1200 行）
- 新增回归测试：构造一个"切片窄但离今天远"的场景，断言 `max_pages` 按深度而非宽度计算
- 全量测试 + lint 通过
