### PR TITLE
fix(stats): avoid OOM when rebuilding large datasets

### DIFF
--- a/src/ashare_lake/storage/stats.py
+++ b/src/ashare_lake/storage/stats.py
@@ -46,7 +46,9 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
+import duckdb
 import polars as pl
+import pyarrow.parquet as pq
 
 from ashare_lake.config import Config
 from ashare_lake.domain.datasets import DATASETS, DatasetSpec
@@ -59,6 +61,10 @@ PARTITION_STATS_FILE = "partition_stats.parquet"
 PROVENANCE_STATS_FILE = "provenance_stats.parquet"
 STATS_SUMMARY_FILE = "stats-latest.json"
 _REBUILD_LOCK = ".rebuild.lock"
+# Above this row count a dataset is considered too large for the historical
+# Polars whole-dataset aggregation path. Large datasets get footer-based
+# partition row counts and a DuckDB column-pruned provenance aggregation.
+LARGE_STATS_ROW_THRESHOLD = 2_000_000
 
 # Column polars fills with the source file of each row. Underscored so it cannot
 # collide with a dataset column.
@@ -167,6 +173,127 @@ def _empty(schema: dict[str, pl.DataType]) -> pl.DataFrame:
     return pl.DataFrame(schema=schema)
 
 
+def _sql_ident(name: str) -> str:
+    """Quote a SQL identifier; all callers pass trusted dataset column names."""
+    return '"' + name.replace('"', '""') + '"'
+
+
+def _parquet_row_count(path: Path) -> int:
+    """Read one file's row count from its footer, never from its data rows."""
+    try:
+        return int(pq.ParquetFile(path).metadata.num_rows)
+    except Exception:
+        # A damaged file already fails normal reads. Stats should still be
+        # able to describe the rest of the lake.
+        return 0
+
+
+def _duckdb_provenance(
+    config: Config, files: list[Path], spec: DatasetSpec
+) -> tuple[pl.DataFrame, dict[str | None, int]]:
+    """Column-pruned provenance aggregation for very large datasets.
+
+    The historical Polars path materialises the same columns plus the source
+    file name and can exhaust a normal container on datasets with hundreds of
+    millions of rows. DuckDB can perform the same grouped aggregation while
+    spilling to disk, so the process keeps the dashboard alive instead of
+    becoming a one-off high-memory job.
+    """
+    scratch = stats_root(config) / "tmp"
+    scratch.mkdir(parents=True, exist_ok=True)
+    con = duckdb.connect(":memory:")
+    try:
+        con.execute(f"SET memory_limit='{config.duckdb_memory_limit}'")
+        con.execute(f"SET threads={config.duckdb_threads}")
+        con.execute(
+            f"PRAGMA temp_directory='{scratch.as_posix().replace(chr(39), chr(39) * 2)}'"
+        )
+        paths = [str(path) for path in files]
+        describe = con.execute(
+            "DESCRIBE SELECT * FROM read_parquet(?, union_by_name=true)", [paths]
+        ).fetchall()
+        names = {str(row[0]) for row in describe}
+        keys = [col for col in _PROVENANCE_KEYS if col in names]
+
+        selected = ["filename AS __source_file"]
+        selected += [_sql_ident(key) for key in keys]
+        selected += ["count(*) AS row_count"]
+        if "fetched_at" in names:
+            selected += [
+                "min(fetched_at) AS fetched_at_min",
+                "max(fetched_at) AS fetched_at_max",
+            ]
+
+        grouped = ["__source_file"]
+        grouped += [_sql_ident(key) for key in keys]
+        query = (
+            f"SELECT {', '.join(selected)} "
+            "FROM read_parquet(?, filename=true, union_by_name=true) "
+            f"GROUP BY {', '.join(grouped)}"
+        )
+        per_file = pl.from_arrow(con.execute(query, [paths]).arrow())
+    finally:
+        con.close()
+
+    per_file = per_file.with_columns(
+        pl.col("__source_file")
+        .map_elements(
+            lambda path: _partition_of(path, spec.partition_col),
+            return_dtype=pl.Utf8,
+        )
+        .alias("partition")
+    )
+
+    rows_by_partition = {
+        row["partition"]: int(row["row_count"])
+        for row in per_file.group_by("partition")
+        .agg(pl.col("row_count").sum())
+        .iter_rows(named=True)
+    }
+
+    if not keys:
+        return _empty(PROVENANCE_STATS_SCHEMA), rows_by_partition
+
+    rollup = [pl.col("row_count").sum().alias("row_count")]
+    if "fetched_at_min" in per_file.columns:
+        rollup += [
+            pl.col("fetched_at_min").min().alias("fetched_at_min"),
+            pl.col("fetched_at_max").max().alias("fetched_at_max"),
+        ]
+    provenance = (
+        per_file.group_by(["partition", *keys])
+        .agg(rollup)
+        .with_columns(pl.lit(spec.name, dtype=pl.Utf8).alias("dataset"))
+    )
+    for col, dtype in PROVENANCE_STATS_SCHEMA.items():
+        if col not in provenance.columns:
+            provenance = provenance.with_columns(pl.lit(None, dtype=dtype).alias(col))
+    provenance = provenance.select(list(PROVENANCE_STATS_SCHEMA)).cast(PROVENANCE_STATS_SCHEMA)
+    return provenance, rows_by_partition
+
+
+def _partition_stats_from_footers(
+    spec: DatasetSpec, groups: dict[str | None, list[Path]]
+) -> pl.DataFrame:
+    """Partition measurements from Parquet footers only."""
+    rows = []
+    for value, files in groups.items():
+        part = parse_partition(value) if value is not None else None
+        rows.append(
+            {
+                "dataset": spec.name,
+                "partition": value,
+                "granularity": granularity_of(part) if part else None,
+                "period_start": part.start if part else None,
+                "period_end": part.end if part else None,
+                "row_count": sum(_parquet_row_count(path) for path in files),
+                "file_count": len(files),
+                "bytes": sum(path.stat().st_size for path in files if path.is_file()),
+            }
+        )
+    return pl.DataFrame(rows, schema=PARTITION_STATS_SCHEMA)
+
+
 def _provenance_for_dataset(
     files: list[Path], spec: DatasetSpec
 ) -> tuple[pl.DataFrame, dict[str | None, int]]:
@@ -236,6 +363,13 @@ def _stats_for_dataset(
         return None
 
     all_files = [f for files in groups.values() for f in files]
+    footer_partitions = _partition_stats_from_footers(spec, groups)
+    estimated_rows = int(footer_partitions["row_count"].sum())
+
+    if estimated_rows > LARGE_STATS_ROW_THRESHOLD:
+        provenance, rows_by_partition = _duckdb_provenance(config, all_files, spec)
+        return footer_partitions, provenance
+
     provenance, rows_by_partition = _provenance_for_dataset(all_files, spec)
 
     partition_rows = []

--- a/tests/unit/test_stats.py
+++ b/tests/unit/test_stats.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 import polars as pl
 import pytest
 
+from ashare_lake.storage import stats as stats_module
 from ashare_lake.file_lock import exclusive_lock
 from ashare_lake.storage.stats import (
     load_partition_stats,
@@ -76,6 +77,25 @@ def test_row_counts_split_by_source_within_one_partition(config):
     assert provenance["source"].to_list() == ["sina", "tdx_protocol"]
     assert provenance["row_count"].to_list() == [1, 2]
     assert provenance["row_count"].sum() == partitions["row_count"].item()
+
+
+def test_large_dataset_provenance_uses_the_spillable_path(config, monkeypatch):
+    """The DuckDB path must preserve the same rows-by-source contract."""
+    monkeypatch.setattr(stats_module, "LARGE_STATS_ROW_THRESHOLD", 0)
+    root = config.curated_root / "daily_bars"
+    _write(
+        root,
+        "trade_date=2026-07-31",
+        [_bar("600519.SH"), _bar("000001.SZ"), _bar("000002.SZ", source="sina")],
+    )
+
+    rebuild_stats(config, datasets=["daily_bars"])
+    partitions = load_partition_stats(config)
+    provenance = load_provenance_stats(config).sort("source")
+
+    assert partitions["row_count"].item() == 3
+    assert provenance["source"].to_list() == ["sina", "tdx_protocol"]
+    assert provenance["row_count"].to_list() == [1, 2]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

`asl stats rebuild` aggregates provenance with Polars over every row in a dataset. For large intraday datasets such as `minute_bars_5m` with 160 million rows, this exhausts a normal 8 GiB pod and still OOMs at 20 GiB.

## Change

Keep the existing Polars path for ordinary datasets and add a large-dataset path:

- partition row counts come from Parquet footers
- provenance aggregation uses DuckDB over only `source`, `data_version`, and `fetched_at`
- DuckDB uses the configured memory limit and spills to `meta/stats/tmp`
- threshold is `2_000_000` rows

## Verification

- `pytest tests/unit/test_stats.py`: 26 passed
- `pytest tests/unit --ignore=tests/unit/test_worker_manifest.py`: 1467 passed, 18 deselected
- `pytest tests/integration`: 6 passed
- Production-like run on `minute_bars_5m`: 491 partitions, 160,048,862 rows in 2.56s without OOM