### PR TITLE
fix: historical ST negative evidence and backfill hardening

### DIFF
--- a/src/ashare_lake/adapters/baostock/st_history.py
+++ b/src/ashare_lake/adapters/baostock/st_history.py
@@ -8,9 +8,14 @@ look-ahead bias (``universe="all_a"`` does not drop names that were ST then).
 Baostock's k-data carries a per-day ``isST`` flag back to 2016, so a per-symbol
 sweep reconstructs the historical ST label. ``isST`` is binary — it does not
 split "ST" from "*ST" — so every ST day maps to ``status="st"``; that is enough
-for the universe filter (``EXCLUDED_STATUSES`` covers both). Only genuinely
-traded ST days are emitted (``tradestatus == 1``); suspension is reconstructed
-separately from bar gaps, so this path stays purely about the ST label.
+for the universe filter (``EXCLUDED_STATUSES`` covers both). Every genuinely
+traded day is emitted: ``status="st"`` when ``isST == 1`` and
+``status="normal"`` when ``isST == 0`` — the negative evidence makes a swept
+non-ST day query-visible instead of indistinguishable from "never checked".
+Suspension is reconstructed separately from bar gaps, so this path emits NO
+rows for non-trading days (``tradestatus != 1``) and stays purely about the ST
+label. Malformed ``isST`` values fail the symbol closed rather than degrading
+to ``normal``.
 """
 
 from __future__ import annotations
@@ -40,10 +45,11 @@ _OUTPUT_SCHEMA = {
 
 
 def _fetch_one_st(bs, symbol: str, start: date, end: date) -> list[dict] | None:
-    """ST-day rows for one symbol, or ``None`` on a retryable query error.
+    """Trading-day rows (st/normal) for one symbol, or ``None`` on failure.
 
-    An ``error_code == '0'`` result with no ST days is a legitimate empty
-    (the name was simply never ST in the window) and returns ``[]``.
+    ``None`` means a retryable provider/symbol failure (query error OR a
+    malformed ``isST`` value — never silently treated as normal). A symbol
+    with no trading days returns ``[]``.
     """
     rs = bs.query_history_k_data_plus(
         to_baostock_symbol(symbol),
@@ -58,14 +64,20 @@ def _fetch_one_st(bs, symbol: str, start: date, end: date) -> list[dict] | None:
     out: list[dict] = []
     while rs.next():
         trade_raw, _code, tradestatus, is_st = rs.get_row_data()
-        if is_st != "1" or tradestatus != "1":
+        if tradestatus != "1":
+            # Non-trading / suspended days are owned by the derived bar-gap
+            # suspension path; Baostock must not emit rows for them.
             continue
+        if is_st not in ("0", "1"):
+            # Malformed/unexpected vocabulary: fail the symbol closed instead
+            # of silently recording a normal day.
+            return None
         out.append(
             {
                 "symbol": symbol,
                 "trade_date": date.fromisoformat(trade_raw),
                 "is_trading": True,
-                "status": "st",
+                "status": "st" if is_st == "1" else "normal",
             }
         )
     return out
@@ -80,12 +92,13 @@ def fetch_st_history(
     sleep=time.sleep,
     config=None,
 ) -> tuple[pl.DataFrame, list[str]]:
-    """Per-symbol historical ST-labelled trading_status rows over ``[start, end]``.
+    """Per-symbol historical trading_status rows over ``[start, end]``.
 
     Returns ``(dataframe, failed_symbols)``. Fail-loud on login failure; each
     symbol is retried with a fresh session + backoff and the still-failing ones
-    are returned so the caller can surface them and resume. A symbol that was
-    never ST contributes zero rows (a legitimate empty, not a failure).
+    are returned so the caller can surface them and resume. A symbol with no
+    trading days contributes zero rows; a traded never-ST symbol contributes
+    ``normal`` rows (negative evidence) — neither is a failure.
 
     ``bs`` / ``sleep`` / ``config`` are injectable for offline tests. Pass
     ``config`` in production for ``[sources.baostock]`` pacing.

--- a/src/ashare_lake/cli/main.py
+++ b/src/ashare_lake/cli/main.py
@@ -780,7 +780,12 @@ def backfill(
     _guard_history_horizon(dataset, start_d)
     if symbols_str:
         symbols = [s.strip().upper() for s in symbols_str.split(",") if s.strip()]
-        _override_scope(cfg, dataset, symbols)
+        if dataset == "trading_status":
+            # Historical ST backfill takes a transient symbol scope (the
+            # step's own checkpoint is scope-aware); no config block needed.
+            cfg._backfill_symbols = symbols
+        else:
+            _override_scope(cfg, dataset, symbols)
         click.echo(f"[{dataset}] scope overridden for this run: {len(symbols)} symbol(s)", err=True)
     if start_d:
         cfg._backfill_start = start_d

--- a/src/ashare_lake/cli/main.py
+++ b/src/ashare_lake/cli/main.py
@@ -2108,7 +2108,31 @@ def delisted_backfill(config_path: str, since: str):
     run_id = engine.manifest.start_run("delisted_backfill", {"since": since})
     result = backfill_delisted_bars(cfg, run_id, date.fromisoformat(since))
     compact_out = engine.run_step("compact", date.today(), run_id)
-    engine.manifest.finish_run(run_id, "success", rows_written=result.get("rows_written", 0))
-    click.echo(
-        json.dumps({"run_id": run_id, **result, "compact": compact_out}, indent=2, default=str)
+
+    failed_n = int(result.get("failed_symbols", 0) or 0)
+    empty_n = int(result.get("empty_symbols", 0) or 0)
+    compact_status = compact_out.get("status")
+    complete = failed_n == 0 and empty_n == 0 and compact_status == "success"
+    run_status = "success" if complete else "failed"
+    error_message = (
+        None
+        if complete
+        else (
+            f"delisted backfill incomplete: failed={failed_n}, empty={empty_n}, compact={compact_status}"
+        )
     )
+    engine.manifest.finish_run(
+        run_id,
+        run_status,
+        rows_written=result.get("rows_written", 0),
+        error_message=error_message,
+    )
+    click.echo(
+        json.dumps(
+            {"run_id": run_id, "status": run_status, **result, "compact": compact_out},
+            indent=2,
+            default=str,
+        )
+    )
+    if not complete:
+        raise click.ClickException(error_message)

--- a/src/ashare_lake/derive/trading_status_history.py
+++ b/src/ashare_lake/derive/trading_status_history.py
@@ -15,7 +15,10 @@ rebuild can run year-by-year without OOM.
 from __future__ import annotations
 
 import logging
-from datetime import date
+from collections.abc import Mapping
+from datetime import date, datetime
+from typing import Any
+from zoneinfo import ZoneInfo
 
 import polars as pl
 
@@ -29,6 +32,55 @@ logger = logging.getLogger(__name__)
 
 _DERIVED_SOURCE = "derived_bar_gap"
 _STATUS_SPEC = DATASETS["trading_status"]
+_DAILY_STATUS_SOURCES = frozenset({"eastmoney", "tdx_protocol"})
+_SHANGHAI_TZ = ZoneInfo("Asia/Shanghai")
+
+
+def _shanghai_date(value: Any) -> date | None:
+    """Wall-clock date in Asia/Shanghai for *value* (UTC-aware or naive)."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        # Naive timestamps are treated as already-UTC (ASL storage norm).
+        value = value.replace(tzinfo=ZoneInfo("UTC"))
+    return value.astimezone(_SHANGHAI_TZ).date()
+
+
+def status_row_precedence_class(row: Mapping[str, Any]) -> str:
+    """Classify one existing ``trading_status`` row for a bar-gap collision.
+
+    Returns one of:
+
+    * ``TRUSTED_SAME_SESSION_DAILY`` — an EastMoney/TDX daily row whose fetch
+      happened on the same Asia/Shanghai session date as its ``trade_date``;
+      it is real same-session evidence and must keep precedence.
+    * ``NON_PIT_DAILY_SNAPSHOT`` — an EastMoney/TDX current-state row fetched
+      on a LATER session than ``trade_date`` (or with unknown fetch time);
+      it is NOT point-in-time evidence for that historical date, so a proven
+      bar-gap suspension wins the PK.
+    * ``BAOSTOCK`` — historical ST rows; preserved, never reclassified.
+    * ``DERIVED_BAR_GAP`` — the generated suspension row itself.
+    * ``OTHER`` — unknown source; preserved, fail closed (no derived override).
+    """
+    source = str(row.get("source") or "")
+    if source == _DERIVED_SOURCE:
+        return "DERIVED_BAR_GAP"
+    if source == "baostock":
+        return "BAOSTOCK"
+    if source in _DAILY_STATUS_SOURCES:
+        trade_date = row.get("trade_date")
+        fetched = _shanghai_date(row.get("fetched_at"))
+        if fetched is not None and isinstance(trade_date, date) and fetched == trade_date:
+            return "TRUSTED_SAME_SESSION_DAILY"
+        return "NON_PIT_DAILY_SNAPSHOT"
+    return "OTHER"
 
 
 def _suspended_pairs(
@@ -157,11 +209,32 @@ def derive_suspension_history(
                 if f.name != "part-merged.parquet":
                     stray_parts.append(f)
         merged = pl.concat(frames, how="diagonal_relaxed")
-        # Real daily rows (non-derived) win on PK overlap: sort them first.
+        if "fetched_at" not in merged.columns:
+            merged = merged.with_columns(pl.lit(None, dtype=pl.Datetime("us")).alias("fetched_at"))
+        # PIT-aware precedence: derived_bar_gap wins ONLY over NON-PIT daily
+        # current-state snapshots. Same-session daily rows, baostock ST rows,
+        # and unknown sources keep precedence (fail closed).
         merged = merged.with_columns(
-            (pl.col("source") == _DERIVED_SOURCE).alias("_is_derived")
-        ).sort("_is_derived")
-        merged = merged.unique(subset=["symbol", "trade_date"], keep="first").drop("_is_derived")
+            pl.struct(["source", "trade_date", "fetched_at"])
+            .map_elements(
+                lambda row: status_row_precedence_class(row),
+                return_dtype=pl.Utf8,
+            )
+            .alias("_prec")
+        )
+        _PRECEDENCE_RANK = {
+            "TRUSTED_SAME_SESSION_DAILY": 0,
+            "BAOSTOCK": 0,
+            "OTHER": 0,
+            "DERIVED_BAR_GAP": 1,
+            "NON_PIT_DAILY_SNAPSHOT": 2,
+        }
+        merged = merged.with_columns(
+            pl.col("_prec").replace_strict(_PRECEDENCE_RANK, default=0).alias("_prec_rank")
+        ).sort("_prec_rank")
+        merged = merged.unique(subset=["symbol", "trade_date"], keep="first").drop(
+            ["_prec", "_prec_rank"]
+        )
         # Reuse compact's filename so we overwrite the single canonical part
         # rather than adding a second file (which would double-count on read).
         writer.write_partition("trading_status", pcol, val, merged, "part-merged.parquet")

--- a/src/ashare_lake/orchestrator/engine.py
+++ b/src/ashare_lake/orchestrator/engine.py
@@ -16,6 +16,8 @@ from ashare_lake.orchestrator.deps import step_execution_levels, validate_steps_
 from ashare_lake.orchestrator.init_phases import (
     DEFAULT_INIT_PHASES,
     INIT_PHASE_STEPS,
+    current_phase_statuses,
+    init_run_complete,
     missing_steps,
     needs_finalize,
     phase_backfill,
@@ -250,7 +252,13 @@ class JobEngine:
         return results, total_read, total_written, had_error, had_warning
 
     def _run_step(
-        self, name: str, trade_date: date, run_id: str, context: dict[str, Any]
+        self,
+        name: str,
+        trade_date: date,
+        run_id: str,
+        context: dict[str, Any],
+        *,
+        retry_of: str | None = None,
     ) -> dict[str, Any]:
         entry = get_step(name)
         uses_worker_batches = entry.requires_workers
@@ -270,6 +278,14 @@ class JobEngine:
                     rows_read=out.get("rows_read", 0),
                     rows_written=out.get("rows_written", 0),
                 )
+                if retry_of is not None:
+                    prior = self.manifest.get_batch(run_id, retry_of)
+                    self.manifest.supersede_batch(
+                        run_id,
+                        retry_of,
+                        superseded_by=batch_id,
+                        prior_error=prior["error_message"] if prior else None,
+                    )
             logger.info("Step %s OK in %.1fs (%s rows)", name, elapsed, out.get("rows_written", 0))
             step_status = out.pop("status", "success")
             return {
@@ -463,7 +479,15 @@ class JobEngine:
 
         for batch in step_batches:
             dataset = batch["dataset"]
-            results.append(self._run_step(dataset, trade_date, run_id, context))
+            results.append(
+                self._run_step(
+                    dataset,
+                    trade_date,
+                    run_id,
+                    context,
+                    retry_of=batch["batch_id"],
+                )
+            )
 
         if missing_init:
             phases = self._init_phases_list(run_id)
@@ -506,14 +530,25 @@ class JobEngine:
         rows_read: int = 0,
         rows_written: int = 0,
     ) -> str:
-        had_failure = any(p.get("status") == "failed" for p in phase_results)
+        # Final status is derived from CURRENT manifest state, not the
+        # historical phase_results snapshot: an originally failed phase whose
+        # batches were later recovered must be able to reach success. The
+        # historical snapshot is preserved for audit alongside the recomputed
+        # current view.
+        phases = self._init_phases_list(run_id)
+        batches = self.manifest.get_batches_for_run(run_id)
+        current = current_phase_statuses(phases, batches)
+        complete = init_run_complete(phases, batches)
         incomplete = self.manifest.incomplete_batch_count(run_id) > 0
-        status = "failed" if had_failure or incomplete else "success"
-        error_message = None
-        if had_failure:
-            error_message = "one or more init phases failed"
+        if not complete:
+            status = "failed"
+            error_message = "one or more init steps are not currently successful"
         elif incomplete:
+            status = "failed"
             error_message = "init run has incomplete batches"
+        else:
+            status = "success"
+            error_message = None
         self.manifest.finish_run(
             run_id,
             status,
@@ -522,7 +557,8 @@ class JobEngine:
             error_message=error_message,
         )
         meta = self.manifest.get_run_metadata(run_id)
-        meta["phase_results"] = phase_results
+        meta["phase_results"] = phase_results  # historical attempts (audit)
+        meta["current_phase_status"] = current  # manifest-derived current view
         self.manifest.update_run_metadata(run_id, meta)
         return status
 

--- a/src/ashare_lake/orchestrator/init_phases.py
+++ b/src/ashare_lake/orchestrator/init_phases.py
@@ -29,6 +29,12 @@ INIT_BACKFILL_PHASES = frozenset(
 
 FINALIZE_STEPS = frozenset({"compact", "derive_adj_factors", "derive_industry_index", "audit"})
 
+# A batch is "resolved" for current-completion purposes when it either
+# succeeded itself or was superseded by a successful retry (see
+# ``Manifest.supersede_batch``). Superseded attempts stay auditable; they are
+# just no longer treated as current incompleteness.
+RESOLVED_BATCH_STATUSES = ("success", "superseded")
+
 DEFAULT_INIT_PHASES = [
     "phase1_reference",
     "phase2a_corporate_actions",
@@ -80,12 +86,35 @@ def step_started(batches: list[Any], step: str) -> bool:
 
 def step_succeeded(batches: list[Any], step: str) -> bool:
     rows = step_batches(batches, step)
-    return bool(rows) and all(r["status"] == "success" for r in rows)
+    return bool(rows) and all(r["status"] in RESOLVED_BATCH_STATUSES for r in rows)
 
 
 def step_incomplete(batches: list[Any], step: str) -> bool:
     rows = step_batches(batches, step)
-    return bool(rows) and any(r["status"] != "success" for r in rows)
+    return bool(rows) and any(r["status"] not in RESOLVED_BATCH_STATUSES for r in rows)
+
+
+def current_phase_statuses(phases: list[str], batches: list[Any]) -> dict[str, str]:
+    """Manifest-derived CURRENT phase statuses — the finalization authority.
+
+    Unlike the historical ``phase_results`` snapshot (which records what the
+    original attempt observed), this recomputes each phase from the manifest's
+    current batch state: ``success`` only when every expected step currently
+    has resolved batches, ``failed`` when any step has an unresolved batch, and
+    ``pending`` when a phase started but nothing failed yet.
+    """
+    out: dict[str, str] = {}
+    for phase in phases:
+        steps = INIT_PHASE_STEPS.get(phase, [])
+        if not steps:
+            continue
+        if all(step_succeeded(batches, step) for step in steps):
+            out[phase] = "success"
+        elif any(step_incomplete(batches, step) for step in steps):
+            out[phase] = "failed"
+        else:
+            out[phase] = "pending"
+    return out
 
 
 def missing_steps(phases: list[str], batches: list[Any]) -> list[str]:

--- a/src/ashare_lake/orchestrator/manifest.py
+++ b/src/ashare_lake/orchestrator/manifest.py
@@ -231,6 +231,37 @@ class Manifest:
                 ),
             )
 
+    def supersede_batch(
+        self,
+        run_id: str,
+        batch_id: str,
+        *,
+        superseded_by: str,
+        prior_error: str | None = None,
+    ) -> None:
+        """Mark a failed/stale attempt as resolved by a successful retry.
+
+        The superseded row is retained for audit (identity, symbols, original
+        timestamps); only ``status`` and ``error_message`` change, and the new
+        message names the successful retry batch plus the prior error text.
+        ``superseded`` batches count as resolved everywhere completeness is
+        computed, so a verified successful retry can supersede an old attempt
+        without deleting history.
+        """
+        message = f"superseded by retry batch {superseded_by}"
+        if prior_error:
+            message = f"{message}; prior: {prior_error}"
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE ingestion_batches
+                SET status = 'superseded', error_message = ?
+                WHERE run_id = ? AND batch_id = ?
+                  AND status IN ('failed', 'stale', 'running')
+                """,
+                (message, run_id, batch_id),
+            )
+
     def get_failed_batches(self, run_id: str) -> list[sqlite3.Row]:
         with self._connect() as conn:
             cur = conn.execute(
@@ -246,7 +277,7 @@ class Manifest:
                 """
                 SELECT dataset, COUNT(*) AS cnt
                 FROM ingestion_batches
-                WHERE run_id = ? AND status != 'success'
+                WHERE run_id = ? AND status NOT IN ('success', 'superseded')
                 GROUP BY dataset
                 """,
                 (run_id,),
@@ -259,7 +290,7 @@ class Manifest:
                 """
                 SELECT COUNT(*) AS cnt
                 FROM ingestion_batches
-                WHERE run_id = ? AND status != 'success'
+                WHERE run_id = ? AND status NOT IN ('success', 'superseded')
                 """,
                 (run_id,),
             )
@@ -271,7 +302,7 @@ class Manifest:
                 """
                 SELECT status, COUNT(*) AS cnt
                 FROM ingestion_batches
-                WHERE run_id = ? AND status != 'success'
+                WHERE run_id = ? AND status NOT IN ('success', 'superseded')
                 GROUP BY status
                 """,
                 (run_id,),

--- a/src/ashare_lake/quality/historical_validity.py
+++ b/src/ashare_lake/quality/historical_validity.py
@@ -115,6 +115,8 @@ def historical_universe_validity(
                     "message": (
                         "delisted coverage is unverified: "
                         f"{counts['pending_probe']} pending probes, "
+                        f"{counts['recent_quarantined']} recent quarantined, "
+                        f"{counts['known_delisted_unreconciled']} known delisted unreconciled, "
                         f"{counts['missing_bars']} missing bars, "
                         f"{counts['unknown_overlap']} unknown overlaps, "
                         f"{counts['terminal_mismatch']} terminal mismatches, "

--- a/src/ashare_lake/steps/bars.py
+++ b/src/ashare_lake/steps/bars.py
@@ -13,7 +13,13 @@ from ashare_lake.config import Config
 from ashare_lake.domain.symbols import split_by_quote_source
 from ashare_lake.orchestrator.registry import register_step
 from ashare_lake.orchestrator.worker_pool import fetch_daily_bars_parallel
-from ashare_lake.steps.common import BACKFILL_START, incremental_window, load_symbols
+from ashare_lake.steps.common import (
+    BACKFILL_START,
+    DailyRouting,
+    classify_daily_routing,
+    incremental_window,
+    load_symbols,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +36,115 @@ def _backfill_window(config: Config, trade_date: date) -> tuple[date, date]:
     return start, end
 
 
+def _instrument_spans(config: Config) -> dict[str, tuple[date | None, date | None]]:
+    """``symbol -> (list_date, delist_date)`` from the routing metadata source."""
+    from ashare_lake.steps.common import instrument_metadata
+
+    meta = instrument_metadata(config)
+    spans: dict[str, tuple[date | None, date | None]] = {}
+    for row in meta.iter_rows(named=True):
+        spans[row["symbol"]] = (row["list_date"], row["delist_date"])
+    return spans
+
+
+def _routing_audit(routing: DailyRouting, start: date, end: date) -> dict:
+    """Deterministic routing counters for the step/context output. No silent drop."""
+    counts = routing.counts()
+    return {
+        "daily_bars_routing": counts,
+        "audit_findings": [
+            {
+                "dataset": "daily_bars",
+                "severity": "info",
+                "check": "daily_bars_delist_aware_routing",
+                "message": (
+                    f"routed {counts['excluded_expected_no_data']} symbol(s) out of "
+                    f"generic {start.isoformat()}..{end.isoformat()} (expected no data) "
+                    f"and {counts['excluded_delegated_delisted']} symbol(s) to the "
+                    f"dedicated delisted path; {counts['generic_included']} fetched generically"
+                ),
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+                **counts,
+            }
+        ],
+    }
+
+
+def _merge_routing_context(out: dict, routing: DailyRouting, start: date, end: date) -> None:
+    payload = _routing_audit(routing, start, end)
+    existing = out.get("context_updates") or {}
+    existing.setdefault("audit_findings", []).extend(payload["audit_findings"])
+    existing["daily_bars_routing"] = payload["daily_bars_routing"]
+    out["context_updates"] = existing
+
+
+def _resolve_excluded_retry_batch(
+    config: Config,
+    run_id: str,
+    batch_id: str,
+    routing: DailyRouting,
+    start: date,
+    end: date,
+    *,
+    keep_identity: bool,
+) -> None:
+    """Terminally resolve a failed generic batch whose symbols are not generic-owned.
+
+    Uses only manifest APIs — no vendor call, no fabricated rows, no manual
+    SQLite edits. An all-excluded batch keeps its original row (batch identity
+    and symbol provenance) and is marked success with zero rows plus an explicit
+    reason. A mixed batch keeps the original id for its generic subset fetch and
+    records the excluded symbols in a sibling ``-delegated`` batch.
+    """
+    from ashare_lake.orchestrator.manifest import Manifest
+
+    manifest = Manifest(config.manifest_path)
+    reason = (
+        f"ROUTED_OUT_OF_GENERIC expected_no_data={len(routing.excluded_expected_no_data)} "
+        f"delegated_delisted={len(routing.excluded_delegated_delisted)} "
+        f"window={start.isoformat()}..{end.isoformat()}"
+    )
+    if keep_identity:
+        if manifest.get_batch(run_id, batch_id) is None:
+            manifest.start_batch(
+                run_id,
+                batch_id,
+                task_id="daily_bars",
+                dataset="daily_bars",
+                symbols=sorted(routing.excluded),
+                window_start=start.isoformat(),
+                window_end=end.isoformat(),
+            )
+        manifest.finish_batch(
+            run_id,
+            batch_id,
+            "success",
+            rows_read=0,
+            rows_written=0,
+            error_message=reason,
+        )
+        return
+    sibling = f"{batch_id}-delegated"
+    manifest.start_batch(
+        run_id,
+        sibling,
+        task_id="daily_bars",
+        dataset="daily_bars",
+        symbols=sorted(routing.excluded),
+        window_start=start.isoformat(),
+        window_end=end.isoformat(),
+    )
+    manifest.finish_batch(
+        run_id,
+        sibling,
+        "success",
+        rows_read=0,
+        rows_written=0,
+        error_message=reason,
+    )
+
+
 @register_step(
     "daily_bars",
     group="core",
@@ -40,11 +155,34 @@ def step_daily_bars(config: Config, trade_date: date, run_id: str, context: dict
     batch_specs = context.get("_retry_batch_specs")
     if batch_specs:
         # Retry windows are encoded on each BatchSpec; tip/multi-day gap-fill
-        # still applies using the outer trade_date / per-spec window.
+        # still applies using the outer trade_date / per-spec window. The same
+        # delist-aware contract applies: only symbols still active through each
+        # spec's window are generic-owned; A/B symbols are resolved through the
+        # explicit delegated/expected-no-data manifest semantic below.
         windows = {(s, e) for _, _, s, e in batch_specs}
         start = min(s for s, _ in windows)
         end = max(e for _, e in windows)
-        expected = [sym for _, syms, _, _ in batch_specs for sym in syms]
+        spans = _instrument_spans(config)
+        remaining: list[tuple[str, list[str], date, date]] = []
+        combined = DailyRouting()
+        for batch_id, syms, spec_start, spec_end in batch_specs:
+            routing = classify_daily_routing(syms, spans, spec_start, spec_end)
+            combined.included.extend(routing.included)
+            combined.excluded_expected_no_data.extend(routing.excluded_expected_no_data)
+            combined.excluded_delegated_delisted.extend(routing.excluded_delegated_delisted)
+            combined.excluded_future_listing.extend(routing.excluded_future_listing)
+            if routing.included:
+                remaining.append((batch_id, routing.included, spec_start, spec_end))
+            if routing.excluded:
+                _resolve_excluded_retry_batch(
+                    config,
+                    run_id,
+                    batch_id,
+                    routing,
+                    spec_start,
+                    spec_end,
+                    keep_identity=not routing.included,
+                )
         result = fetch_daily_bars_parallel(
             config,
             [],
@@ -52,18 +190,20 @@ def step_daily_bars(config: Config, trade_date: date, run_id: str, context: dict
             end,
             run_id,
             "daily_bars",
-            batch_specs=batch_specs,
+            batch_specs=remaining,
         )
-        return _finish_daily_bars(
+        out = _finish_daily_bars(
             config,
             trade_date,
             run_id,
             start=start,
             end=end,
-            expected_tdx_symbols=list(dict.fromkeys(expected)),
+            expected_tdx_symbols=list(dict.fromkeys(combined.included)),
             tdx_result=result,
             sina_result=None,
         )
+        _merge_routing_context(out, combined, start, end)
+        return out
 
     symbols = load_symbols(config)
     rebackfill = context.get("symbols_to_rebackfill") or []
@@ -76,11 +216,14 @@ def step_daily_bars(config: Config, trade_date: date, run_id: str, context: dict
         start = incremental_window(config, "daily_bars", trade_date)
         end = trade_date
 
+    routing = classify_daily_routing(symbols, _instrument_spans(config), start, end)
+    generic_symbols = routing.included
+
     # TDX has no Beijing exchange route at all — the protocol rejects the market id —
     # so BJ symbols must come from the fallback vendor or they silently never
     # arrive, which is exactly how the lake ended up with zero BJ coverage.
     # Tip gaps after TDX are a second routing case (ADR-0005): EastMoney clist.
-    tdx_symbols, fallback_symbols = split_by_quote_source(symbols)
+    tdx_symbols, fallback_symbols = split_by_quote_source(generic_symbols)
     result = fetch_daily_bars_parallel(
         config,
         tdx_symbols,
@@ -94,7 +237,7 @@ def step_daily_bars(config: Config, trade_date: date, run_id: str, context: dict
         sina_result = fetch_bars_via_sina(
             config, fallback_symbols, start, end, run_id, batch_prefix="sina"
         )
-    return _finish_daily_bars(
+    out = _finish_daily_bars(
         config,
         trade_date,
         run_id,
@@ -104,6 +247,8 @@ def step_daily_bars(config: Config, trade_date: date, run_id: str, context: dict
         tdx_result=result,
         sina_result=sina_result,
     )
+    _merge_routing_context(out, routing, start, end)
+    return out
 
 
 def _finish_daily_bars(

--- a/src/ashare_lake/steps/common.py
+++ b/src/ashare_lake/steps/common.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from datetime import date, timedelta
 
 import polars as pl
@@ -208,6 +209,101 @@ def load_symbols(config: Config) -> list[str]:
         config=config,
     )
     return df["symbol"].to_list()
+
+
+def instrument_metadata(config: Config) -> pl.DataFrame:
+    """Narrow instrument metadata (``symbol``, ``list_date``, ``delist_date``).
+
+    Reads only what is already on disk (curated → staging) — never a network
+    fetch, so routing stays offline and cheap. Keeps the listing/delisting
+    dates, which generic daily routing needs to keep already-delisted symbols
+    out of the TDX/EastMoney backfill. Columns absent from a stored frame are
+    filled with nulls rather than failing, so legacy fixtures without dates
+    still classify as active.
+    """
+    curated = config.curated_root / "instruments" / "part-merged.parquet"
+    staging_glob = list(config.staging_root.glob("instruments/run_id=*/part-*.parquet"))
+    if curated.exists():
+        df = pl.read_parquet(curated)
+    elif staging_glob:
+        latest = max(staging_glob, key=lambda p: p.stat().st_mtime)
+        df = pl.read_parquet(latest)
+    else:
+        return pl.DataFrame(
+            schema={"symbol": pl.Utf8, "list_date": pl.Date, "delist_date": pl.Date}
+        )
+    cols = [c for c in ("symbol", "list_date", "delist_date") if c in df.columns]
+    if "symbol" not in cols:
+        return pl.DataFrame(
+            schema={"symbol": pl.Utf8, "list_date": pl.Date, "delist_date": pl.Date}
+        )
+    out = df.select(cols)
+    for col in ("list_date", "delist_date"):
+        if col not in out.columns:
+            out = out.with_columns(pl.lit(None, dtype=pl.Date).alias(col))
+    return out
+
+
+@dataclass
+class DailyRouting:
+    """Delist-aware routing of symbols for one generic daily-bars window.
+
+    ``included`` — symbols still active through the window (``delist_date`` null
+    or after ``end``); the only ones the generic TDX/EastMoney path fetches.
+
+    ``excluded_expected_no_data`` — delisted before ``start`` (no trading overlap
+    with the window, nothing to fetch anywhere) plus symbols listed after
+    ``end`` (no bars can exist inside the window).
+
+    ``excluded_delegated_delisted`` — delisted inside ``[start, end]``; their
+    history belongs to the dedicated delisted recovery path.
+    """
+
+    included: list[str] = field(default_factory=list)
+    excluded_expected_no_data: list[str] = field(default_factory=list)
+    excluded_delegated_delisted: list[str] = field(default_factory=list)
+    excluded_future_listing: list[str] = field(default_factory=list)
+
+    @property
+    def excluded(self) -> list[str]:
+        return self.excluded_expected_no_data + self.excluded_delegated_delisted
+
+    def counts(self) -> dict[str, int]:
+        return {
+            "generic_included": len(self.included),
+            "excluded_expected_no_data": len(self.excluded_expected_no_data),
+            "excluded_delegated_delisted": len(self.excluded_delegated_delisted),
+            "excluded_future_listing": len(self.excluded_future_listing),
+        }
+
+
+def classify_daily_routing(
+    symbols: list[str],
+    spans: dict[str, tuple[date | None, date | None]],
+    start: date,
+    end: date,
+) -> DailyRouting:
+    """Classify *symbols* for generic daily backfill over ``[start, end]``.
+
+    A symbol with ``delist_date <= end`` must not be sent to the generic
+    TDX/EastMoney path: it belongs to the dedicated delisted recovery (or, when
+    it delisted before ``start``, to no fetch at all). Symbols listed after
+    ``end`` have no bars inside the window and are excluded too. Symbols missing
+    from *spans* are treated as active — conservative, never a silent drop.
+    """
+    routing = DailyRouting()
+    for symbol in symbols:
+        list_date, delist_date = spans.get(symbol, (None, None))
+        if delist_date is not None and delist_date < start:
+            routing.excluded_expected_no_data.append(symbol)
+        elif delist_date is not None and delist_date <= end:
+            routing.excluded_delegated_delisted.append(symbol)
+        elif list_date is not None and list_date > end:
+            routing.excluded_future_listing.append(symbol)
+            routing.excluded_expected_no_data.append(symbol)
+        else:
+            routing.included.append(symbol)
+    return routing
 
 
 def load_bar_universe(config: Config) -> set[str]:

--- a/src/ashare_lake/steps/delisted.py
+++ b/src/ashare_lake/steps/delisted.py
@@ -329,6 +329,34 @@ def delisted_symbols_in_window(config: Config, start: date) -> list[str]:
     return sorted(s for s, last in catalog.items() if last >= start and s not in already)
 
 
+def delisted_backfill_targets(config: Config, start: date, as_of: date) -> list[str]:
+    """Unified dedicated-recovery targets: formal authority + definite catalogue.
+
+    The generic daily path delegates every symbol with ``delist_date <= as_of``
+    out of TDX/EastMoney; this selector is the dedicated pipeline's side of the
+    same ownership contract. A symbol is a recovery target when EITHER:
+
+    * FORMAL — ``instruments.delist_date`` is on/before *as_of* (known
+      delisting, decisive) and on/after *start*; or
+    * UNAMBIGUOUS_CATALOG — the probe catalogue classifies it as genuinely
+      delisted with ``last_traded >= start``.
+
+    Probe-only recent terminals (``LIVE_RECENCY_DAYS`` quarantine) stay
+    excluded; formal authority resolves identity immediately. ``delist_date <
+    start`` is expected-no-data; ``delist_date > as_of`` would be
+    future-information leakage and is never a target. Already-ingested symbols
+    are dropped; a symbol present in both authorities appears exactly once.
+    """
+    formal = {
+        symbol
+        for symbol, formal in known_delisted_instruments(config, as_of).items()
+        if formal >= start
+    }
+    catalog = {symbol for symbol, last in load_delisted_catalog(config).items() if last >= start}
+    already = _ingested_symbols(config)
+    return sorted(s for s in formal | catalog if s not in already)
+
+
 def _instruments_rows(config: Config, spans: dict[str, tuple[date | None, date]]) -> pl.DataFrame:
     """instruments rows for the recovered names, unioned with the live snapshot.
 
@@ -445,9 +473,11 @@ def delisted_coverage_report(
     Ownership closure: every symbol the *formal* instrument metadata says
     delisted on/before ``end`` must end in an explicit state. Formal
     ``instruments.delist_date`` is decisive even while its probe evidence is
-    still inside ``LIVE_RECENCY_DAYS`` (known delisting), and probe-only recent
-    terminals overlapping the window keep the report fail-closed
-    (``recent_quarantined``) instead of letting coverage silently pass.
+    still inside ``LIVE_RECENCY_DAYS``: the symbol is evaluated against bars
+    and instruments like any other required target (``catalog_recent_quarantined``
+    stays a diagnostic only). Probe-only recent terminals with no formal
+    authority keep the report fail-closed (``recent_quarantined``) instead of
+    letting coverage silently pass.
     """
     end = end or _reference_date(config)
     if start > end:
@@ -457,7 +487,12 @@ def delisted_coverage_report(
 
     catalog = load_delisted_catalog(config)
     candidates = {symbol: last for symbol, last in catalog.items() if last >= start}
-    symbols = sorted(candidates)
+    # Formal authority is known before the bars scan: known-delisted symbols
+    # quarantined at catalogue level are required targets too, so their bars
+    # must be scanned alongside the unambiguous catalogue candidates.
+    known = known_delisted_instruments(config, end)
+    known_in_window = {symbol: formal for symbol, formal in known.items() if formal >= start}
+    symbols = sorted(set(candidates) | set(known_in_window))
 
     spans: dict[str, tuple[date, date]] = {}
     bars_root = config.curated_root / "daily_bars"
@@ -503,7 +538,7 @@ def delisted_coverage_report(
     invalid_delist_dates: list[dict] = []
     proven_overlap = 0
 
-    for symbol in symbols:
+    for symbol in sorted(candidates):
         catalog_last = candidates[symbol]
         span = spans.get(symbol)
         overlap_is_definite = catalog_last <= end
@@ -546,8 +581,6 @@ def delisted_coverage_report(
 
     pending = pending_codes(config)
     # Recency/identity closure (Source A vs Source B of the recency contract).
-    known = known_delisted_instruments(config, end)
-    known_in_window = {symbol: formal for symbol, formal in known.items() if formal >= start}
     raw_catalog = _read_catalog(config)["delisted"]
     live_missing = classify_catalog(config)[1]
 
@@ -556,41 +589,70 @@ def delisted_coverage_report(
         for symbol, formal in sorted(known.items())
         if formal < start
     ]
-    recent_quarantined: list[dict] = []
-    for symbol, last in sorted(live_missing.items()):
-        if last >= start and symbol not in known_in_window:
-            recent_quarantined.append(
-                {
-                    "symbol": symbol,
-                    "probe_last_traded": last.isoformat(),
-                    "basis": "probe_only",
-                }
-            )
+    # Probe-only recent terminals (no formal authority): quarantine, fail-closed.
+    recent_quarantined: list[dict] = [
+        {
+            "symbol": symbol,
+            "probe_last_traded": last.isoformat(),
+            "basis": "probe_only",
+        }
+        for symbol, last in sorted(live_missing.items())
+        if last >= start and symbol not in known_in_window
+    ]
+    # Known-delisted symbols still quarantined at catalogue level: diagnostic
+    # only — formal authority resolves identity, so they are evaluated against
+    # bars/instruments by the formal-target loop below.
+    catalog_recent_quarantined: list[dict] = [
+        {
+            "symbol": symbol,
+            "formal_delist_date": formal.isoformat(),
+            "probe_last_traded": live_missing[symbol].isoformat(),
+        }
+        for symbol, formal in sorted(known_in_window.items())
+        if symbol in live_missing
+    ]
     unreconciled: list[dict] = []
     for symbol, formal in sorted(known_in_window.items()):
-        if symbol in candidates:
+        if symbol in candidates or symbol in live_missing:
             continue  # the main loop above owns the full evidence check
-        if symbol in live_missing:
-            recent_quarantined.append(
+        raw_last = raw_catalog.get(symbol)
+        unreconciled.append(
+            {
+                "symbol": symbol,
+                "formal_delist_date": formal.isoformat(),
+                **({"catalog_last_traded": raw_last} if raw_last is not None else {}),
+                "reason": (
+                    "catalog_terminal_before_window_conflicts_with_formal"
+                    if raw_last is not None
+                    else "not_discovered"
+                ),
+            }
+        )
+    # Formal-only targets (quarantined at catalogue level): bars are required,
+    # recovered bars prove the overlap, and a bar after the formal delisting
+    # date contradicts identity.
+    for symbol, formal in sorted(known_in_window.items()):
+        if symbol in candidates:
+            continue
+        span = spans.get(symbol)
+        if span is None:
+            missing_bars.append(
                 {
                     "symbol": symbol,
                     "formal_delist_date": formal.isoformat(),
-                    "probe_last_traded": live_missing[symbol].isoformat(),
-                    "basis": "known_delisted_quarantined",
+                    "catalog_last_traded": None,
                 }
             )
-        else:
-            raw_last = raw_catalog.get(symbol)
-            unreconciled.append(
+            continue
+        proven_overlap += 1
+        actual = instrument_dates.get(symbol)
+        if actual is None or actual < span[1]:
+            invalid_delist_dates.append(
                 {
                     "symbol": symbol,
+                    "catalog_last_traded": None,
                     "formal_delist_date": formal.isoformat(),
-                    **({"catalog_last_traded": raw_last} if raw_last is not None else {}),
-                    "reason": (
-                        "catalog_terminal_before_window_conflicts_with_formal"
-                        if raw_last is not None
-                        else "not_discovered"
-                    ),
+                    "instrument_delist_date": actual.isoformat() if actual else None,
                 }
             )
 
@@ -625,6 +687,7 @@ def delisted_coverage_report(
             "known_delisted_in_window": len(known_in_window),
             "expected_no_data": len(expected_no_data),
             "recent_quarantined": len(recent_quarantined),
+            "catalog_recent_quarantined": len(catalog_recent_quarantined),
             "known_delisted_unreconciled": len(unreconciled),
             "missing_bars": len(missing_bars),
             "unknown_overlap": len(unknown_overlap),
@@ -636,6 +699,7 @@ def delisted_coverage_report(
             "pending_probe": limited(pending),
             "expected_no_data": limited(expected_no_data),
             "recent_quarantined": limited(recent_quarantined),
+            "catalog_recent_quarantined": limited(catalog_recent_quarantined),
             "known_delisted_unreconciled": limited(unreconciled),
             "missing_bars": limited(missing_bars),
             "unknown_overlap": limited(unknown_overlap),
@@ -927,7 +991,12 @@ def backfill_delisted_bars(
     *,
     fetch=None,
 ) -> dict:
-    """Fetch full price history for catalogued delistings and stage it.
+    """Fetch full price history for known-delisted recovery targets and stage it.
+
+    The target set is the unified recovery selector: formal instrument
+    authority (``delist_date <= as_of``, decisive even under catalogue
+    quarantine) unioned with unambiguous probe-catalogue terminals. Probe-only
+    recent terminals stay quarantined by ``LIVE_RECENCY_DAYS``.
 
     Bars land in ``daily_bars`` alongside the live names with ``source='sina'``:
     the same kind of fact from a different vendor, which is what the provenance
@@ -944,9 +1013,9 @@ def backfill_delisted_bars(
     fetch = fetch or (
         lambda symbol, client: fetch_daily_bars_sina(symbol, start=start, client=client)
     )
-    todo = delisted_symbols_in_window(config, start)
+    todo = delisted_backfill_targets(config, start, _reference_date(config))
     if not todo:
-        return {"rows_read": 0, "rows_written": 0, "note": "no catalogued delistings to ingest"}
+        return {"rows_read": 0, "rows_written": 0, "note": "no delisted recovery targets to ingest"}
 
     logger.info("delisted bars: %d symbol(s) to fetch from %s", len(todo), start.isoformat())
     rows_written = 0

--- a/src/ashare_lake/steps/delisted.py
+++ b/src/ashare_lake/steps/delisted.py
@@ -1003,6 +1003,12 @@ def backfill_delisted_bars(
     columns exist for. ``adj_factors`` picks them up on the next derive because
     it iterates the symbols present in ``daily_bars``.
 
+    Only symbols with actually recovered bars are marked ingested. A raised
+    fetch and an empty response are both unresolved evidence for a recovery
+    target — the symbol stays out of ``delisted_ingested`` and is retried on
+    the next run, surfaced as ``failed_symbols`` / ``empty_symbols`` with a
+    ``delisted_backfill_incomplete`` audit finding.
+
     Staged in chunks so an interrupted multi-hour sweep keeps what it fetched,
     with the per-symbol date spans accumulated across chunks — they are what the
     ``instruments`` rows are built from at the end.
@@ -1020,6 +1026,7 @@ def backfill_delisted_bars(
     logger.info("delisted bars: %d symbol(s) to fetch from %s", len(todo), start.isoformat())
     rows_written = 0
     failed: list[str] = []
+    empty: list[str] = []
     spans: dict[str, tuple[date, date]] = {}
     events: list[dict] = []
     pending_frames: list[pl.DataFrame] = []
@@ -1052,20 +1059,26 @@ def backfill_delisted_bars(
                 logger.warning("delisted bars: fetch failed for %s: %s", symbol, exc)
                 failed.append(symbol)
                 continue
-            if not bars.is_empty():
-                pending_frames.append(bars)
-                spans[symbol] = (bars["trade_date"].min(), bars["trade_date"].max())
-                # Classified from the *full* fetched series, before the window
-                # filter — the halt and the resumption drop are what identify a
-                # consolidation period, and they sit at the very end.
-                events.append(
-                    {
-                        "symbol": symbol,
-                        "first_trade_date": bars["trade_date"].min(),
-                        "last_trade_date": bars["trade_date"].max(),
-                        **classify_ending(bars),
-                    }
-                )
+            if bars.is_empty():
+                # Empty history for a target that provably overlapped the window
+                # is unresolved evidence, not successful ingestion: keep it
+                # retryable and never mark it done.
+                logger.warning("delisted bars: empty response for %s", symbol)
+                empty.append(symbol)
+                continue
+            pending_frames.append(bars)
+            spans[symbol] = (bars["trade_date"].min(), bars["trade_date"].max())
+            # Classified from the *full* fetched series, before the window
+            # filter — the halt and the resumption drop are what identify a
+            # consolidation period, and they sit at the very end.
+            events.append(
+                {
+                    "symbol": symbol,
+                    "first_trade_date": bars["trade_date"].min(),
+                    "last_trade_date": bars["trade_date"].max(),
+                    **classify_ending(bars),
+                }
+            )
             pending_symbols.append(symbol)
             if index % _INGEST_CHUNK == 0:
                 flush(index // _INGEST_CHUNK)
@@ -1086,15 +1099,17 @@ def backfill_delisted_bars(
         "recovered": len(spans),
         "ending_patterns": dict(Counter(e["ending_pattern"] for e in events)),
     }
-    if failed:
+    if failed or empty:
         result["failed_symbols"] = len(failed)
+        result["empty_symbols"] = len(empty)
         result.setdefault("context_updates", {})["audit_findings"] = [
             {
                 "dataset": "daily_bars",
                 "severity": "warning",
                 "check": "delisted_backfill_incomplete",
                 "message": (
-                    f"{len(failed)}/{len(todo)} delisted symbols failed to fetch; re-run to resume"
+                    f"{len(failed)} failed / {len(empty)} empty of {len(todo)} "
+                    "delisted recovery targets; re-run to resume"
                 ),
             }
         ]

--- a/src/ashare_lake/steps/delisted.py
+++ b/src/ashare_lake/steps/delisted.py
@@ -158,9 +158,57 @@ def load_live_missing(config: Config) -> dict[str, date]:
     return classify_catalog(config)[1]
 
 
+def _live_symbols(config: Config) -> set[str]:
+    """Instruments still trading as of the lake's reference date.
+
+    A code with a historical ``delist_date`` is NOT live merely because an
+    instruments row exists — masking it would keep it out of the discovery
+    sweep forever, which is survivorship bias at the catalogue level. Only rows
+    with no ``delist_date`` or one after the reference date count as live.
+    """
+    from ashare_lake.steps.common import instrument_metadata
+
+    meta = instrument_metadata(config)
+    if meta.is_empty():
+        # No instruments on disk yet: fall back to the historic universe
+        # semantics (nothing is provably delisted, so everything is live).
+        from ashare_lake.steps.common import load_symbols
+
+        return set(load_symbols(config))
+    ref = _reference_date(config)
+    return set(
+        meta.filter(
+            pl.col("delist_date").is_null() | (pl.col("delist_date") > ref)
+        )["symbol"].to_list()
+    )
+
+
+def known_delisted_instruments(config: Config, as_of: date) -> dict[str, date]:
+    """Instrument-authoritative delistings: ``symbol -> formal delist_date``.
+
+    Source B of the recency contract. ``instruments.delist_date`` is the formal
+    exchange delisting date (baostock ``outDate`` for merged delisted names,
+    bar-derived spans for the dedicated Sina recovery path) — not a probe
+    ``last_seen``. A formal date on or before *as_of* is decisive: the symbol
+    stopped trading and must not be treated as live merely because a probe has
+    not aged past ``LIVE_RECENCY_DAYS`` yet.
+    """
+    from ashare_lake.steps.common import instrument_metadata
+
+    meta = instrument_metadata(config)
+    if meta.is_empty() or "delist_date" not in meta.columns:
+        return {}
+    out: dict[str, date] = {}
+    for row in meta.filter(pl.col("delist_date").is_not_null()).iter_rows(named=True):
+        formal = row["delist_date"]
+        if formal <= as_of:
+            out[row["symbol"]] = formal
+    return out
+
+
 def pending_codes(config: Config) -> list[str]:
     """Issued codes neither listed today nor already classified by a prior sweep."""
-    live = set(load_symbols(config))
+    live = _live_symbols(config)
     catalog = _read_catalog(config)
     done = set(catalog["delisted"]) | set(catalog["never_issued"])
     return [s for s in issued_code_space() if s not in live and s not in done]
@@ -393,6 +441,13 @@ def delisted_coverage_report(
     already listed during the requested window. If no bar establishes that
     overlap, the name is reported as ``unknown_overlap`` instead of being
     silently treated as out of scope.
+
+    Ownership closure: every symbol the *formal* instrument metadata says
+    delisted on/before ``end`` must end in an explicit state. Formal
+    ``instruments.delist_date`` is decisive even while its probe evidence is
+    still inside ``LIVE_RECENCY_DAYS`` (known delisting), and probe-only recent
+    terminals overlapping the window keep the report fail-closed
+    (``recent_quarantined``) instead of letting coverage silently pass.
     """
     end = end or _reference_date(config)
     if start > end:
@@ -490,6 +545,55 @@ def delisted_coverage_report(
             )
 
     pending = pending_codes(config)
+    # Recency/identity closure (Source A vs Source B of the recency contract).
+    known = known_delisted_instruments(config, end)
+    known_in_window = {symbol: formal for symbol, formal in known.items() if formal >= start}
+    raw_catalog = _read_catalog(config)["delisted"]
+    live_missing = classify_catalog(config)[1]
+
+    expected_no_data = [
+        {"symbol": symbol, "delist_date": formal.isoformat()}
+        for symbol, formal in sorted(known.items())
+        if formal < start
+    ]
+    recent_quarantined: list[dict] = []
+    for symbol, last in sorted(live_missing.items()):
+        if last >= start and symbol not in known_in_window:
+            recent_quarantined.append(
+                {
+                    "symbol": symbol,
+                    "probe_last_traded": last.isoformat(),
+                    "basis": "probe_only",
+                }
+            )
+    unreconciled: list[dict] = []
+    for symbol, formal in sorted(known_in_window.items()):
+        if symbol in candidates:
+            continue  # the main loop above owns the full evidence check
+        if symbol in live_missing:
+            recent_quarantined.append(
+                {
+                    "symbol": symbol,
+                    "formal_delist_date": formal.isoformat(),
+                    "probe_last_traded": live_missing[symbol].isoformat(),
+                    "basis": "known_delisted_quarantined",
+                }
+            )
+        else:
+            raw_last = raw_catalog.get(symbol)
+            unreconciled.append(
+                {
+                    "symbol": symbol,
+                    "formal_delist_date": formal.isoformat(),
+                    **({"catalog_last_traded": raw_last} if raw_last is not None else {}),
+                    "reason": (
+                        "catalog_terminal_before_window_conflicts_with_formal"
+                        if raw_last is not None
+                        else "not_discovered"
+                    ),
+                }
+            )
+
     known_coverage_complete = not any(
         (
             missing_bars,
@@ -497,6 +601,8 @@ def delisted_coverage_report(
             terminal_mismatches,
             missing_instruments,
             invalid_delist_dates,
+            recent_quarantined,
+            unreconciled,
         )
     )
     discovery_complete = not pending
@@ -515,6 +621,11 @@ def delisted_coverage_report(
             "catalogue_candidates": len(candidates),
             "proven_overlap": proven_overlap,
             "pending_probe": len(pending),
+            "known_delisted_instruments": len(known),
+            "known_delisted_in_window": len(known_in_window),
+            "expected_no_data": len(expected_no_data),
+            "recent_quarantined": len(recent_quarantined),
+            "known_delisted_unreconciled": len(unreconciled),
             "missing_bars": len(missing_bars),
             "unknown_overlap": len(unknown_overlap),
             "terminal_mismatch": len(terminal_mismatches),
@@ -523,6 +634,9 @@ def delisted_coverage_report(
         },
         "samples": {
             "pending_probe": limited(pending),
+            "expected_no_data": limited(expected_no_data),
+            "recent_quarantined": limited(recent_quarantined),
+            "known_delisted_unreconciled": limited(unreconciled),
             "missing_bars": limited(missing_bars),
             "unknown_overlap": limited(unknown_overlap),
             "terminal_mismatch": limited(terminal_mismatches),

--- a/src/ashare_lake/steps/delisted.py
+++ b/src/ashare_lake/steps/delisted.py
@@ -38,7 +38,7 @@ import polars as pl
 
 from ashare_lake.config import Config
 from ashare_lake.domain.symbols import issued_code_space
-from ashare_lake.steps.common import is_trading_day, load_symbols
+from ashare_lake.steps.common import is_trading_day
 
 logger = logging.getLogger(__name__)
 
@@ -177,9 +177,9 @@ def _live_symbols(config: Config) -> set[str]:
         return set(load_symbols(config))
     ref = _reference_date(config)
     return set(
-        meta.filter(
-            pl.col("delist_date").is_null() | (pl.col("delist_date") > ref)
-        )["symbol"].to_list()
+        meta.filter(pl.col("delist_date").is_null() | (pl.col("delist_date") > ref))[
+            "symbol"
+        ].to_list()
     )
 
 

--- a/src/ashare_lake/steps/delisted.py
+++ b/src/ashare_lake/steps/delisted.py
@@ -337,7 +337,9 @@ def delisted_backfill_targets(config: Config, start: date, as_of: date) -> list[
     same ownership contract. A symbol is a recovery target when EITHER:
 
     * FORMAL — ``instruments.delist_date`` is on/before *as_of* (known
-      delisting, decisive) and on/after *start*; or
+      delisting, decisive identity) and on/after *start*, UNLESS an
+      authoritative catalogue terminal proves it stopped trading before
+      ``start`` — formal identity does not by itself prove window overlap; or
     * UNAMBIGUOUS_CATALOG — the probe catalogue classifies it as genuinely
       delisted with ``last_traded >= start``.
 
@@ -352,9 +354,13 @@ def delisted_backfill_targets(config: Config, start: date, as_of: date) -> list[
         for symbol, formal in known_delisted_instruments(config, as_of).items()
         if formal >= start
     }
-    catalog = {symbol for symbol, last in load_delisted_catalog(config).items() if last >= start}
+    catalog = load_delisted_catalog(config)
+    # A formal candidate whose catalogue terminal is before the window has no
+    # trading overlap: expected-no-data, not a recovery target.
+    formal -= {symbol for symbol, last in catalog.items() if last < start}
+    catalog_in_window = {symbol for symbol, last in catalog.items() if last >= start}
     already = _ingested_symbols(config)
-    return sorted(s for s in formal | catalog if s not in already)
+    return sorted(s for s in formal | catalog_in_window if s not in already)
 
 
 def _instruments_rows(config: Config, spans: dict[str, tuple[date | None, date]]) -> pl.DataFrame:
@@ -420,6 +426,19 @@ def _instruments_rows(config: Config, spans: dict[str, tuple[date | None, date]]
     return pl.concat([live, recovered], how="diagonal_relaxed").unique(
         subset=["symbol"], keep="first"
     )
+
+
+def _record_catalog_terminal(config: Config, symbol: str, last_traded: date) -> None:
+    """Persist a probed last-traded terminal via the atomic catalogue store.
+
+    Reuses the existing discovery catalogue semantics (``symbol ->
+    last_traded``): a pre-window terminal makes the symbol expected-no-data for
+    this window, so target selection naturally excludes it on the next run.
+    Only the vendor terminal is stored — never the formal ``delist_date``.
+    """
+    catalog = _read_catalog(config)
+    catalog["delisted"][symbol] = last_traded.isoformat()
+    _write_catalog(config, catalog)
 
 
 def _bar_spans(
@@ -611,10 +630,38 @@ def delisted_coverage_report(
         for symbol, formal in sorted(known_in_window.items())
         if symbol in live_missing
     ]
+    # Window-overlap closure: formal identity (``delist_date``) does NOT by
+    # itself prove overlap with ``[start, end]`` — the last-traded authority
+    # decides. Observed in-window bars prove overlap (even with no catalogue);
+    # a catalogue terminal before ``start`` proves no overlap
+    # (expected-no-data); anything else is unresolved and fails closed.
+    formal_no_overlap: list[dict] = []
     unreconciled: list[dict] = []
     for symbol, formal in sorted(known_in_window.items()):
-        if symbol in candidates or symbol in live_missing:
+        if symbol in candidates:
             continue  # the main loop above owns the full evidence check
+        cat_last = catalog.get(symbol)
+        if cat_last is not None and cat_last < start:
+            formal_no_overlap.append(
+                {
+                    "symbol": symbol,
+                    "formal_delist_date": formal.isoformat(),
+                    "catalog_last_traded": cat_last.isoformat(),
+                }
+            )
+            continue
+        span = spans.get(symbol)
+        if span is not None:
+            continue  # observed bars prove overlap (counted below)
+        if symbol in live_missing:
+            missing_bars.append(
+                {
+                    "symbol": symbol,
+                    "formal_delist_date": formal.isoformat(),
+                    "catalog_last_traded": None,
+                }
+            )
+            continue
         raw_last = raw_catalog.get(symbol)
         unreconciled.append(
             {
@@ -628,22 +675,16 @@ def delisted_coverage_report(
                 ),
             }
         )
-    # Formal-only targets (quarantined at catalogue level): bars are required,
-    # recovered bars prove the overlap, and a bar after the formal delisting
-    # date contradicts identity.
+    # Formal-only symbols with observed bars: proven overlap + identity check.
     for symbol, formal in sorted(known_in_window.items()):
         if symbol in candidates:
             continue
+        cat_last = catalog.get(symbol)
+        if cat_last is not None and cat_last < start:
+            continue  # expected-no-data, handled above
         span = spans.get(symbol)
         if span is None:
-            missing_bars.append(
-                {
-                    "symbol": symbol,
-                    "formal_delist_date": formal.isoformat(),
-                    "catalog_last_traded": None,
-                }
-            )
-            continue
+            continue  # handled above (missing_bars / unreconciled)
         proven_overlap += 1
         actual = instrument_dates.get(symbol)
         if actual is None or actual < span[1]:
@@ -685,6 +726,9 @@ def delisted_coverage_report(
             "pending_probe": len(pending),
             "known_delisted_instruments": len(known),
             "known_delisted_in_window": len(known_in_window),
+            "known_formal_candidates": len(known_in_window),
+            "known_overlap_required": len(known_in_window) - len(formal_no_overlap),
+            "formal_no_overlap": len(formal_no_overlap),
             "expected_no_data": len(expected_no_data),
             "recent_quarantined": len(recent_quarantined),
             "catalog_recent_quarantined": len(catalog_recent_quarantined),
@@ -698,6 +742,7 @@ def delisted_coverage_report(
         "samples": {
             "pending_probe": limited(pending),
             "expected_no_data": limited(expected_no_data),
+            "formal_no_overlap": limited(formal_no_overlap),
             "recent_quarantined": limited(recent_quarantined),
             "catalog_recent_quarantined": limited(catalog_recent_quarantined),
             "known_delisted_unreconciled": limited(unreconciled),
@@ -990,6 +1035,7 @@ def backfill_delisted_bars(
     start: date,
     *,
     fetch=None,
+    probe_last=None,
 ) -> dict:
     """Fetch full price history for known-delisted recovery targets and stage it.
 
@@ -1004,21 +1050,24 @@ def backfill_delisted_bars(
     it iterates the symbols present in ``daily_bars``.
 
     Only symbols with actually recovered bars are marked ingested. A raised
-    fetch and an empty response are both unresolved evidence for a recovery
-    target — the symbol stays out of ``delisted_ingested`` and is retried on
-    the next run, surfaced as ``failed_symbols`` / ``empty_symbols`` with a
-    ``delisted_backfill_incomplete`` audit finding.
+    fetch stays unresolved (``failed_symbols``). An empty window fetch is
+    resolved against the Sina last-traded probe: a terminal before ``start`` is
+    ``PROVEN_NO_OVERLAP`` (expected-no-data — persisted to the catalogue, never
+    ingested, not a failure); a missing, contradictory or failing probe stays
+    unresolved (``empty_symbols``). Both unresolved kinds remain retryable and
+    surface a ``delisted_backfill_incomplete`` audit finding.
 
     Staged in chunks so an interrupted multi-hour sweep keeps what it fetched,
     with the per-symbol date spans accumulated across chunks — they are what the
     ``instruments`` rows are built from at the end.
     """
-    from ashare_lake.adapters.sina.bars import fetch_daily_bars_sina
+    from ashare_lake.adapters.sina.bars import fetch_daily_bars_sina, symbol_exists
     from ashare_lake.steps.http_common import write_fetched
 
     fetch = fetch or (
         lambda symbol, client: fetch_daily_bars_sina(symbol, start=start, client=client)
     )
+    probe_last = probe_last or (lambda symbol, client: symbol_exists(symbol, client=client))
     todo = delisted_backfill_targets(config, start, _reference_date(config))
     if not todo:
         return {"rows_read": 0, "rows_written": 0, "note": "no delisted recovery targets to ingest"}
@@ -1026,7 +1075,8 @@ def backfill_delisted_bars(
     logger.info("delisted bars: %d symbol(s) to fetch from %s", len(todo), start.isoformat())
     rows_written = 0
     failed: list[str] = []
-    empty: list[str] = []
+    unresolved: list[str] = []
+    no_overlap: list[str] = []
     spans: dict[str, tuple[date, date]] = {}
     events: list[dict] = []
     pending_frames: list[pl.DataFrame] = []
@@ -1060,11 +1110,40 @@ def backfill_delisted_bars(
                 failed.append(symbol)
                 continue
             if bars.is_empty():
-                # Empty history for a target that provably overlapped the window
-                # is unresolved evidence, not successful ingestion: keep it
-                # retryable and never mark it done.
-                logger.warning("delisted bars: empty response for %s", symbol)
-                empty.append(symbol)
+                # Empty window fetch: distinguish "vendor has no evidence" from
+                # "vendor history exists but ends before the window".
+                try:
+                    last_traded = probe_last(symbol, client)
+                except Exception as exc:  # noqa: BLE001 — probe outage stays retryable
+                    logger.warning("delisted bars: probe failed for %s: %s", symbol, exc)
+                    unresolved.append(symbol)
+                    continue
+                if last_traded is None:
+                    # Formal identity says the security existed, so this is not
+                    # "never issued" — it is unresolved, never-issued must not
+                    # be inferred from a missing probe answer.
+                    logger.warning("delisted bars: no terminal evidence for %s", symbol)
+                    unresolved.append(symbol)
+                    continue
+                if last_traded >= start:
+                    # Vendor claims window overlap but the window fetch was
+                    # empty: contradictory evidence, stay retryable.
+                    logger.warning(
+                        "delisted bars: empty fetch but probe last_traded %s >= start for %s",
+                        last_traded,
+                        symbol,
+                    )
+                    unresolved.append(symbol)
+                    continue
+                # PROVEN_NO_OVERLAP: the vendor's last traded session is before
+                # the window — expected-no-data, resolved, no bars fabricated.
+                logger.info(
+                    "delisted bars: %s last traded %s before window — expected no data",
+                    symbol,
+                    last_traded,
+                )
+                no_overlap.append(symbol)
+                _record_catalog_terminal(config, symbol, last_traded)
                 continue
             pending_frames.append(bars)
             spans[symbol] = (bars["trade_date"].min(), bars["trade_date"].max())
@@ -1097,18 +1176,20 @@ def backfill_delisted_bars(
         "rows_written": rows_written,
         "symbols": len(todo),
         "recovered": len(spans),
+        "no_overlap_symbols": len(no_overlap),
         "ending_patterns": dict(Counter(e["ending_pattern"] for e in events)),
     }
-    if failed or empty:
+    if failed or unresolved:
         result["failed_symbols"] = len(failed)
-        result["empty_symbols"] = len(empty)
+        result["empty_symbols"] = len(unresolved)
         result.setdefault("context_updates", {})["audit_findings"] = [
             {
                 "dataset": "daily_bars",
                 "severity": "warning",
                 "check": "delisted_backfill_incomplete",
                 "message": (
-                    f"{len(failed)} failed / {len(empty)} empty of {len(todo)} "
+                    f"{len(failed)} failed / {len(unresolved)} unresolved empty "
+                    f"of {len(todo)} "
                     "delisted recovery targets; re-run to resume"
                 ),
             }

--- a/src/ashare_lake/steps/reference.py
+++ b/src/ashare_lake/steps/reference.py
@@ -480,6 +480,11 @@ def _backfill_trading_status_st(config: Config, trade_date: date, run_id: str) -
         "scope_end": scope["end"],
     }
     if all_failed:
+        # Partial provider failures are truthfully a WARNING: the successful
+        # symbols' staging must still be compacted (the engine/CLI compact on
+        # warning too), the run must not report success, and the failed
+        # symbols stay out of the checkpoint (retryable).
+        result["status"] = "warning"
         result["failed_symbols"] = len(all_failed)
         finding = {
             "dataset": "trading_status",

--- a/src/ashare_lake/steps/reference.py
+++ b/src/ashare_lake/steps/reference.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import logging
 import os
+import re
 import tempfile
 from datetime import date, timedelta
+from pathlib import Path
 
 import polars as pl
 
@@ -40,6 +43,8 @@ _ST_BACKFILL_STATE = "trading_status_st_backfill"
 # Flush + checkpoint every chunk so a mid-sweep baostock login death does not
 # discard hours of already-fetched ST rows (observed ~2950/5204 lost on one run).
 _ST_BACKFILL_CHUNK = 200
+_ST_SCOPE_VERSION = 1
+_ST_SYMBOL_RE = re.compile(r"^\d{6}(\.(SH|SZ|BJ))?$")
 
 
 @register_step("instruments", group="core", requires_workers=False)
@@ -274,8 +279,61 @@ def _st_backfill_state_path(config: Config):
     return config.meta_root / "state" / f"{_ST_BACKFILL_STATE}.json"
 
 
+def _st_scope(config: Config, trade_date: date) -> tuple[dict, str | None]:
+    """Resolve the ST backfill scope and its deterministic identity.
+
+    Returns ``(scope, scope_id)`` where ``scope_id`` is None for the LEGACY
+    default scope (BACKFILL_START, default all-A universe) and a SHA-256 of
+    the canonical ``{start, end, symbol_hash}`` payload for any custom scope
+    (explicit ``--start`` / ``--end`` / ``--symbols``). A custom scope's
+    checkpoint can never be confused with another scope's completion state.
+    """
+    start = getattr(config, "_backfill_start", None)
+    end = getattr(config, "_backfill_end", None)
+    explicit = getattr(config, "_backfill_symbols", None)
+    custom = start is not None or end is not None or explicit is not None
+    start_d = start or BACKFILL_START
+    end_d = end or trade_date
+    if start_d > end_d:
+        raise ValueError(
+            f"trading_status ST backfill window inverted: start {start_d} > end {end_d}"
+        )
+    symbol_scope = sorted(set(explicit)) if explicit is not None else None
+    symbol_hash = None
+    if symbol_scope is not None:
+        symbol_hash = hashlib.sha256(
+            json.dumps(symbol_scope, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+    scope = {
+        "scope_version": _ST_SCOPE_VERSION,
+        "start": start_d.isoformat(),
+        "end": end_d.isoformat(),
+        "symbol_hash": symbol_hash,
+    }
+    if not custom:
+        return scope, None
+    scope_id = hashlib.sha256(
+        json.dumps(scope, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return scope, scope_id
+
+
+def _st_scope_checkpoint_path(config: Config, scope_id: str | None) -> Path:
+    """Checkpoint path: legacy file for the default scope, per-scope dir else."""
+    if scope_id is None:
+        return _st_backfill_state_path(config)
+    return config.meta_root / "state" / _ST_BACKFILL_STATE / f"{scope_id}.json"
+
+
 def _st_backfilled_symbols(config: Config) -> set[str]:
     path = _st_backfill_state_path(config)
+    if not path.exists():
+        return set()
+    return set(json.loads(path.read_text(encoding="utf-8")).get("completed", []))
+
+
+def _st_completed_symbols(config: Config, scope_id: str | None) -> set[str]:
+    path = _st_scope_checkpoint_path(config, scope_id)
     if not path.exists():
         return set()
     return set(json.loads(path.read_text(encoding="utf-8")).get("completed", []))
@@ -297,8 +355,62 @@ def _mark_st_backfilled(config: Config, symbols: list[str]) -> None:
         raise
 
 
+def _mark_st_completed(
+    config: Config,
+    scope_id: str | None,
+    scope: dict,
+    symbols: list[str],
+) -> None:
+    """Atomically checkpoint ``symbols`` for one explicit ST backfill scope."""
+    path = _st_scope_checkpoint_path(config, scope_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    completed = sorted(_st_completed_symbols(config, scope_id) | set(symbols))
+    payload = dict(scope)
+    payload["completed"] = completed
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=f".{path.stem}-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+        os.replace(tmp, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+def _resolve_st_scope_symbols(config: Config, raw: list[str]) -> list[str]:
+    """Normalize and validate an explicit ST symbol scope (fail closed)."""
+    instruments = set(load_symbols(config))
+    resolved: list[str] = []
+    for value in raw:
+        symbol = str(value).strip().upper()
+        if not _ST_SYMBOL_RE.match(symbol):
+            raise ValueError(f"trading_status ST backfill: malformed symbol {value!r}")
+        if "." in symbol:
+            if symbol not in instruments:
+                raise ValueError(f"trading_status ST backfill: unknown instrument {symbol!r}")
+            resolved.append(symbol)
+            continue
+        matches = [s for s in instruments if s.startswith(symbol + ".")]
+        if len(matches) != 1:
+            raise ValueError(
+                f"trading_status ST backfill: cannot resolve {value!r} "
+                f"to exactly one instrument ({len(matches)} found)"
+            )
+        resolved.append(matches[0])
+    return sorted(set(resolved))
+
+
 def _backfill_trading_status_st(config: Config, trade_date: date, run_id: str) -> dict:
     """Historical ST labels from baostock over the all_a universe (2016 → today).
+
+    The sweep window honours the caller's ``_backfill_start`` /
+    ``_backfill_end`` (default: ``BACKFILL_START`` → ``trade_date``), and an
+    explicit ``_backfill_symbols`` scope restricts the universe to exactly
+    those symbols. A custom scope checkpoints under its own deterministic
+    scope identity, so a bounded run can never poison a deeper/full run's
+    resume state; the legacy checkpoint file keeps its meaning for the legacy
+    default scope only.
 
     Fills the ``trading_status`` ST gap so ``universe="all_a"`` excludes names that
     were ST in earlier backtest windows (removes survivorship / look-ahead bias).
@@ -309,7 +421,12 @@ def _backfill_trading_status_st(config: Config, trade_date: date, run_id: str) -
     """
     from ashare_lake.adapters.baostock.st_history import fetch_st_history
 
-    universe = [s for s in load_symbols(config) if _is_all_a(s)]
+    scope, scope_id = _st_scope(config, trade_date)
+    explicit = getattr(config, "_backfill_symbols", None)
+    if explicit is not None:
+        universe = _resolve_st_scope_symbols(config, explicit)
+    else:
+        universe = [s for s in load_symbols(config) if _is_all_a(s)]
     # Only sweep names that have price bars: a delisted symbol still sitting in the
     # instruments list would otherwise cost a baostock round-trip with no bar to
     # join its ST label against. Skip the constraint on a bars-less lake so a
@@ -317,17 +434,27 @@ def _backfill_trading_status_st(config: Config, trade_date: date, run_id: str) -
     bar_universe = load_bar_universe(config)
     if bar_universe:
         universe = [s for s in universe if s in bar_universe]
-    done = _st_backfilled_symbols(config)
+    done = _st_completed_symbols(config, scope_id)
     todo = [s for s in universe if s not in done]
     if not todo:
-        return {"rows_read": 0, "rows_written": 0, "note": "all symbols already ST-backfilled"}
+        return {
+            "rows_read": 0,
+            "rows_written": 0,
+            "note": "all symbols already ST-backfilled",
+            "scope_id": scope_id,
+        }
 
     rows_read = 0
     rows_written = 0
     all_failed: list[str] = []
     for offset in range(0, len(todo), _ST_BACKFILL_CHUNK):
         batch = todo[offset : offset + _ST_BACKFILL_CHUNK]
-        df, failed = fetch_st_history(batch, BACKFILL_START, trade_date, config=config)
+        df, failed = fetch_st_history(
+            batch,
+            date.fromisoformat(scope["start"]),
+            date.fromisoformat(scope["end"]),
+            config=config,
+        )
         if not df.is_empty():
             chunk = write_fetched(
                 config,
@@ -342,10 +469,16 @@ def _backfill_trading_status_st(config: Config, trade_date: date, run_id: str) -
         failed_set = set(failed)
         swept = [s for s in batch if s not in failed_set]
         if swept:
-            _mark_st_backfilled(config, swept)
+            _mark_st_completed(config, scope_id, scope, swept)
         all_failed.extend(failed)
 
-    result: dict = {"rows_read": rows_read, "rows_written": rows_written}
+    result: dict = {
+        "rows_read": rows_read,
+        "rows_written": rows_written,
+        "scope_id": scope_id,
+        "scope_start": scope["start"],
+        "scope_end": scope["end"],
+    }
     if all_failed:
         result["failed_symbols"] = len(all_failed)
         finding = {

--- a/src/ashare_lake/steps/reference.py
+++ b/src/ashare_lake/steps/reference.py
@@ -254,10 +254,11 @@ def step_trading_status(config: Config, trade_date: date, run_id: str, context: 
     )
     if df.is_empty():
         return {"rows_read": 0, "rows_written": 0}
-    if "source" not in df.columns:
-        df = normalize_with_source(df)
-    else:
-        df = with_provenance(df, source="eastmoney", data_version="v1")
+    # EastMoney is the only daily status provider; rows fetched here are
+    # current-state snapshots and must not be stamped as TDX (the dataset's
+    # nominal primary source). Correct provenance matters for the
+    # derived-suspension merge precedence later.
+    df = with_provenance(df.drop("source", strict=False), source="eastmoney", data_version="v1")
     return write_simple(config, run_id, "trading_status", df)
 
 

--- a/tests/unit/test_baostock_st_history.py
+++ b/tests/unit/test_baostock_st_history.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, timezone
 
+import polars as pl
 import pytest
 
 from ashare_lake.adapters.baostock.st_history import fetch_st_history
 from ashare_lake.domain.schemas import PRIMARY_KEYS, TRADING_STATUS_SCHEMA
+from ashare_lake.storage import StagingWriter
+from ashare_lake.storage.parquet import compact_dataset
 
 
 class _FakeResultSet:
@@ -51,7 +54,7 @@ def _rows(code, days):
     return [[d, code, ts, st] for d, ts, st in days]
 
 
-def test_emits_only_traded_st_days():
+def test_emits_traded_st_and_normal_days_but_not_suspensions():
     bs = _FakeBaostock(
         {
             "sz.000017": _rows(
@@ -61,6 +64,7 @@ def test_emits_only_traded_st_days():
                     ("2020-04-29", "1", "1"),  # ST day -> emitted
                     ("2020-04-30", "0", "1"),  # ST but suspended -> skipped
                     ("2020-05-06", "1", "1"),  # ST day -> emitted
+                    ("2020-05-07", "1", "0"),  # back to normal -> emitted normal
                 ],
             )
         }
@@ -71,9 +75,14 @@ def test_emits_only_traded_st_days():
 
     assert bs.logged_out is True
     assert failed == []
-    assert df.height == 2
-    assert df["trade_date"].sort().to_list() == [date(2020, 4, 29), date(2020, 5, 6)]
-    assert df["status"].unique().to_list() == ["st"]
+    assert df.height == 4
+    assert df["trade_date"].sort().to_list() == [
+        date(2020, 4, 28),
+        date(2020, 4, 29),
+        date(2020, 5, 6),
+        date(2020, 5, 7),
+    ]
+    assert df["status"].to_list() == ["normal", "st", "st", "normal"]
     assert df["is_trading"].unique().to_list() == [True]
     # columns are the curated trading_status contract minus provenance
     assert set(df.columns) == set(TRADING_STATUS_SCHEMA) - {"source", "data_version", "fetched_at"}
@@ -82,13 +91,116 @@ def test_emits_only_traded_st_days():
     assert df.unique(subset=pk).height == df.height
 
 
-def test_never_st_symbol_is_legit_empty_not_failure():
-    bs = _FakeBaostock({"sz.000001": _rows("sz.000001", [("2020-01-02", "1", "0")])})
+def test_never_st_symbol_now_emits_normal_rows_not_empty():
+    """A swept non-ST traded day is query-visible normal evidence."""
+    bs = _FakeBaostock(
+        {
+            "sz.000001": _rows(
+                "sz.000001",
+                [
+                    ("2020-01-02", "1", "0"),
+                    ("2020-01-03", "1", "0"),
+                ],
+            )
+        }
+    )
+    df, failed = fetch_st_history(
+        ["000001.SZ"], date(2020, 1, 1), date(2020, 12, 31), bs=bs, sleep=lambda _: None
+    )
+    assert failed == []
+    assert df.height == 2
+    assert df["status"].to_list() == ["normal", "normal"]
+
+
+def test_no_trading_days_is_empty_but_not_failure():
+    bs = _FakeBaostock({"sz.000001": _rows("sz.000001", [("2020-01-02", "0", "0")])})
     df, failed = fetch_st_history(
         ["000001.SZ"], date(2020, 1, 1), date(2020, 12, 31), bs=bs, sleep=lambda _: None
     )
     assert failed == []
     assert df.is_empty()
+
+
+def test_malformed_isst_fails_symbol_closed():
+    """Unknown isST vocabulary must NOT silently become normal."""
+    bs = _FakeBaostock({"sz.000017": _rows("sz.000017", [("2020-04-29", "1", "X")])})
+    df, failed = fetch_st_history(
+        ["000017.SZ"], date(2020, 1, 1), date(2020, 12, 31), bs=bs, sleep=lambda _: None
+    )
+    assert df.is_empty()
+    assert failed == ["000017.SZ"]
+
+
+def _status_row(
+    symbol: str,
+    trade_date: date,
+    *,
+    status: str,
+    source: str,
+    fetched_at: datetime,
+) -> dict:
+    return {
+        "symbol": symbol,
+        "trade_date": trade_date,
+        "is_trading": True,
+        "status": status,
+        "source": source,
+        "data_version": "v1",
+        "fetched_at": fetched_at,
+    }
+
+
+def _compact_winner(
+    tmp_path,
+    *,
+    baostock_status: str,
+) -> pl.DataFrame:
+    """Stage a stale tdx current-state row + a new baostock row, compact, read back."""
+    run_id = "run-1"
+    writer = StagingWriter(tmp_path / "staging")
+    stale = pl.DataFrame(
+        [
+            _status_row(
+                "600000.SH",
+                date(2026, 8, 4),
+                status="normal",
+                source="tdx_protocol",
+                fetched_at=datetime(2026, 8, 10, 1, 32, tzinfo=timezone.utc),
+            )
+        ]
+    )
+    fresh = pl.DataFrame(
+        [
+            _status_row(
+                "600000.SH",
+                date(2026, 8, 4),
+                status=baostock_status,
+                source="baostock",
+                fetched_at=datetime(2026, 8, 10, 13, 0, tzinfo=timezone.utc),
+            )
+        ]
+    )
+    writer.write_batch("trading_status", run_id, "stale", stale)
+    writer.write_batch("trading_status", run_id, "fresh", fresh)
+    compact_dataset(
+        tmp_path / "staging",
+        tmp_path / "curated",
+        "trading_status",
+        run_id,
+        partition_col="trade_date",
+    )
+    files = list((tmp_path / "curated" / "trading_status").rglob("*.parquet"))
+    return pl.read_parquet(files[0]).filter(pl.col("symbol") == "600000.SH")
+
+
+@pytest.mark.parametrize("baostock_status", ["st", "normal"])
+def test_compact_baostock_wins_over_stale_current_state_pk(tmp_path, baostock_status):
+    """For this run, the newly fetched baostock row must win the PK on compact."""
+    row = _compact_winner(tmp_path, baostock_status=baostock_status)
+    assert row.height == 1
+    assert row["source"][0] == "baostock"
+    assert row["status"][0] == baostock_status
+    assert row["is_trading"][0] is True
 
 
 def test_reports_failed_symbols_fail_loud():

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -661,7 +661,7 @@ def test_delisted_backfill(cfg_path, monkeypatch):
             self.manifest = FakeManifest()
 
         def run_step(self, name, trade_date, run_id):
-            return {"rows_written": 4}
+            return {"status": "success", "rows_written": 4}
 
     monkeypatch.setattr("ashare_lake.cli.main.JobEngine", FakeEngine)
     monkeypatch.setattr(

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -57,6 +57,39 @@ def test_config_validate_ok(cfg_path):
     assert "Configuration OK" in result.output
 
 
+def test_backfill_trading_status_accepts_symbol_scope(cfg_path, monkeypatch):
+    """--symbols on trading_status routes into a transient backfill scope."""
+    captured: dict = {}
+
+    def fake_backfill_once(cfg, dataset):
+        captured["symbols"] = getattr(cfg, "_backfill_symbols", None)
+        captured["start"] = getattr(cfg, "_backfill_start", None)
+        captured["end"] = getattr(cfg, "_backfill_end", None)
+        return {"status": "success", "rows_read": 0, "rows_written": 0}
+
+    monkeypatch.setattr("ashare_lake.cli.main._backfill_once", fake_backfill_once)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "backfill",
+            "trading_status",
+            "--config",
+            cfg_path,
+            "--start",
+            "2026-03-30",
+            "--end",
+            "2026-08-07",
+            "--symbols",
+            "600000.SH,000001.SZ",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["symbols"] == ["600000.SH", "000001.SZ"]
+    assert captured["start"] == date(2026, 3, 30)
+    assert captured["end"] == date(2026, 8, 7)
+
+
 def test_config_validate_reports_errors(tmp_path):
     cfg_path = tmp_path / "bad.toml"
     cfg_path.write_text(

--- a/tests/unit/test_delisted_backfill_cli.py
+++ b/tests/unit/test_delisted_backfill_cli.py
@@ -1,0 +1,222 @@
+"""`asl delisted backfill` run-status truthfulness (fail-closed ledger)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+import ashare_lake.steps.delisted as delisted_mod
+from ashare_lake.cli.main import cli
+from ashare_lake.config import load_config
+from ashare_lake.config.bootstrap import path_for_toml
+from ashare_lake.orchestrator.engine import JobEngine
+from ashare_lake.orchestrator.manifest import Manifest
+from ashare_lake.storage.layout import init_data_layout
+
+
+@pytest.fixture
+def cfg_path(tmp_path) -> str:
+    path = tmp_path / "test.toml"
+    path.write_text(
+        f"""
+[data]
+root = "{path_for_toml(tmp_path / "data")}"
+
+[orchestrator]
+workers = 1
+batch_size = 100
+
+[tdx_protocol]
+allow_mock = true
+"""
+    )
+    cfg = load_config(path)
+    init_data_layout(cfg)
+    return str(path)
+
+
+def _result(*, failed=0, empty=0, recovered=0, rows=0, symbols=0, note=None) -> dict:
+    out = {
+        "rows_read": rows,
+        "rows_written": rows,
+        "symbols": symbols,
+        "recovered": recovered,
+        "ending_patterns": {},
+    }
+    if failed:
+        out["failed_symbols"] = failed
+    if empty:
+        out["empty_symbols"] = empty
+    if note:
+        out["note"] = note
+    return out
+
+
+def _compact(status: str) -> dict:
+    return {"status": status, "rows_written": 0}
+
+
+def _invoke(cfg_path: str) -> tuple[int, dict]:
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["delisted", "backfill", "--config", cfg_path, "--since", "2023-08-07"]
+    )
+    # JSON is printed before the ClickException message on incomplete runs.
+    payload = json.loads(result.output[: result.output.rindex("}") + 1])
+    return result.exit_code, payload
+
+
+def _run_status(cfg_path: str, run_id: str) -> str:
+    manifest = Manifest(load_config(cfg_path).manifest_path)
+    return manifest.get_run(run_id)["status"]
+
+
+def _run_error(cfg_path: str, run_id: str) -> str:
+    manifest = Manifest(load_config(cfg_path).manifest_path)
+    return manifest.get_run(run_id)["error_message"] or ""
+
+
+def test_all_success_is_success_and_exit_zero(cfg_path, monkeypatch):
+    monkeypatch.setattr(
+        delisted_mod,
+        "backfill_delisted_bars",
+        lambda *a, **k: _result(recovered=1, rows=10, symbols=1),
+    )
+    monkeypatch.setattr(
+        JobEngine,
+        "run_step",
+        lambda self, name, trade_date, run_id, context=None: _compact("success"),
+    )
+
+    exit_code, payload = _invoke(cfg_path)
+
+    assert exit_code == 0
+    assert payload["status"] == "success"
+    assert _run_status(cfg_path, payload["run_id"]) == "success"
+
+
+def test_failed_symbol_is_failed_and_nonzero(cfg_path, monkeypatch):
+    monkeypatch.setattr(
+        delisted_mod,
+        "backfill_delisted_bars",
+        lambda *a, **k: _result(failed=2, rows=3, symbols=2),
+    )
+    monkeypatch.setattr(
+        JobEngine,
+        "run_step",
+        lambda self, name, trade_date, run_id, context=None: _compact("success"),
+    )
+
+    exit_code, payload = _invoke(cfg_path)
+
+    assert exit_code != 0
+    assert payload["status"] == "failed"
+    assert "failed=2" in _run_error(cfg_path, payload["run_id"])
+    assert _run_status(cfg_path, payload["run_id"]) == "failed"
+
+
+def test_empty_symbol_is_failed_and_nonzero(cfg_path, monkeypatch):
+    monkeypatch.setattr(
+        delisted_mod,
+        "backfill_delisted_bars",
+        lambda *a, **k: _result(empty=1, rows=0, symbols=1),
+    )
+    monkeypatch.setattr(
+        JobEngine,
+        "run_step",
+        lambda self, name, trade_date, run_id, context=None: _compact("success"),
+    )
+
+    exit_code, payload = _invoke(cfg_path)
+
+    assert exit_code != 0
+    assert payload["status"] == "failed"
+    assert "empty=1" in _run_error(cfg_path, payload["run_id"])
+    assert _run_status(cfg_path, payload["run_id"]) == "failed"
+
+
+def test_mixed_partial_preserved_and_failed(cfg_path, monkeypatch):
+    monkeypatch.setattr(
+        delisted_mod,
+        "backfill_delisted_bars",
+        lambda *a, **k: _result(failed=1, empty=1, recovered=1, rows=5, symbols=3),
+    )
+    monkeypatch.setattr(
+        JobEngine,
+        "run_step",
+        lambda self, name, trade_date, run_id, context=None: _compact("success"),
+    )
+
+    exit_code, payload = _invoke(cfg_path)
+
+    assert exit_code != 0
+    assert payload["status"] == "failed"
+    assert payload["rows_written"] == 5  # successful symbols preserved
+    assert "failed=1, empty=1" in _run_error(cfg_path, payload["run_id"])
+    assert _run_status(cfg_path, payload["run_id"]) == "failed"
+
+
+def test_second_retry_finishes_success(cfg_path, monkeypatch):
+    state = {"calls": 0}
+
+    def flaky(*a, **k):
+        state["calls"] += 1
+        if state["calls"] == 1:
+            return _result(failed=1, empty=1, recovered=1, rows=5, symbols=3)
+        return _result(recovered=2, rows=10, symbols=2)
+
+    monkeypatch.setattr(delisted_mod, "backfill_delisted_bars", flaky)
+    monkeypatch.setattr(
+        JobEngine,
+        "run_step",
+        lambda self, name, trade_date, run_id, context=None: _compact("success"),
+    )
+
+    first_exit, first = _invoke(cfg_path)
+    second_exit, second = _invoke(cfg_path)
+
+    assert first_exit != 0 and first["status"] == "failed"
+    assert _run_status(cfg_path, first["run_id"]) == "failed"
+    assert second_exit == 0 and second["status"] == "success"
+    assert _run_status(cfg_path, second["run_id"]) == "success"
+
+
+def test_compact_failure_fails_run(cfg_path, monkeypatch):
+    monkeypatch.setattr(
+        delisted_mod,
+        "backfill_delisted_bars",
+        lambda *a, **k: _result(recovered=1, rows=10, symbols=1),
+    )
+    monkeypatch.setattr(
+        JobEngine,
+        "run_step",
+        lambda self, name, trade_date, run_id, context=None: _compact("failed"),
+    )
+
+    exit_code, payload = _invoke(cfg_path)
+
+    assert exit_code != 0
+    assert payload["status"] == "failed"
+    assert "compact=failed" in _run_error(cfg_path, payload["run_id"])
+    assert _run_status(cfg_path, payload["run_id"]) == "failed"
+
+
+def test_zero_targets_is_success(cfg_path, monkeypatch):
+    monkeypatch.setattr(
+        delisted_mod,
+        "backfill_delisted_bars",
+        lambda *a, **k: _result(note="no delisted recovery targets to ingest"),
+    )
+    monkeypatch.setattr(
+        JobEngine,
+        "run_step",
+        lambda self, name, trade_date, run_id, context=None: _compact("success"),
+    )
+
+    exit_code, payload = _invoke(cfg_path)
+
+    assert exit_code == 0
+    assert payload["status"] == "success"
+    assert _run_status(cfg_path, payload["run_id"]) == "success"

--- a/tests/unit/test_delisted_backfill_cli.py
+++ b/tests/unit/test_delisted_backfill_cli.py
@@ -37,7 +37,7 @@ allow_mock = true
     return str(path)
 
 
-def _result(*, failed=0, empty=0, recovered=0, rows=0, symbols=0, note=None) -> dict:
+def _result(*, failed=0, empty=0, recovered=0, rows=0, symbols=0, note=None, no_overlap=0) -> dict:
     out = {
         "rows_read": rows,
         "rows_written": rows,
@@ -49,6 +49,8 @@ def _result(*, failed=0, empty=0, recovered=0, rows=0, symbols=0, note=None) -> 
         out["failed_symbols"] = failed
     if empty:
         out["empty_symbols"] = empty
+    if no_overlap:
+        out["no_overlap_symbols"] = no_overlap
     if note:
         out["note"] = note
     return out
@@ -219,4 +221,25 @@ def test_zero_targets_is_success(cfg_path, monkeypatch):
 
     assert exit_code == 0
     assert payload["status"] == "success"
+    assert _run_status(cfg_path, payload["run_id"]) == "success"
+
+
+def test_no_overlap_resolved_is_success_not_failure(cfg_path, monkeypatch):
+    """Proven no-overlap is resolved, not a failure (per window-overlap contract)."""
+    monkeypatch.setattr(
+        delisted_mod,
+        "backfill_delisted_bars",
+        lambda *a, **k: _result(no_overlap=5, symbols=5),
+    )
+    monkeypatch.setattr(
+        JobEngine,
+        "run_step",
+        lambda self, name, trade_date, run_id, context=None: _compact("success"),
+    )
+
+    exit_code, payload = _invoke(cfg_path)
+
+    assert exit_code == 0
+    assert payload["status"] == "success"
+    assert payload["no_overlap_symbols"] == 5
     assert _run_status(cfg_path, payload["run_id"]) == "success"

--- a/tests/unit/test_delisted_ingest.py
+++ b/tests/unit/test_delisted_ingest.py
@@ -166,6 +166,7 @@ def test_a_symbol_with_empty_bars_is_kept_retryable_and_not_ingested(tmp_path):
         "run-1",
         _START,
         fetch=lambda s, c: pl.DataFrame(schema={c: DAILY_BARS_SCHEMA[c] for c in _BAR_COLS}),
+        probe_last=lambda s, c: None,
     )
 
     assert result["recovered"] == 0
@@ -213,6 +214,7 @@ def test_empty_formal_target_kept_retryable(tmp_path):
         "run-1",
         _START,
         fetch=lambda s, c: pl.DataFrame(schema={c: DAILY_BARS_SCHEMA[c] for c in _BAR_COLS}),
+        probe_last=lambda s, c: None,
     )
 
     assert result["empty_symbols"] == 1
@@ -238,7 +240,13 @@ def test_mixed_chunk_preserves_success_and_keeps_empty_exception_retryable(tmp_p
             return pl.DataFrame(schema={c: DAILY_BARS_SCHEMA[c] for c in _BAR_COLS})
         raise ConnectionError("provider down")
 
-    result = backfill_delisted_bars(cfg, "run-1", _START, fetch=mixed)
+    result = backfill_delisted_bars(
+        cfg,
+        "run-1",
+        _START,
+        fetch=mixed,
+        probe_last=lambda s, c: None,
+    )
 
     assert result["recovered"] == 1
     assert result["empty_symbols"] == 1

--- a/tests/unit/test_delisted_ingest.py
+++ b/tests/unit/test_delisted_ingest.py
@@ -11,6 +11,7 @@ from ashare_lake.steps.delisted import (
     _ingested_symbols,
     backfill_delisted_bars,
     catalog_path,
+    delisted_backfill_targets,
     delisted_symbols_in_window,
 )
 from ashare_lake.storage.parquet import StagingWriter
@@ -156,8 +157,8 @@ def test_rerun_is_a_noop_once_everything_is_ingested(tmp_path):
     assert "no delisted recovery targets" in result["note"]
 
 
-def test_a_symbol_with_no_bars_is_marked_done_but_adds_no_instrument(tmp_path):
-    """Catalogued but empty: do not retry forever, and do not invent a listing."""
+def test_a_symbol_with_empty_bars_is_kept_retryable_and_not_ingested(tmp_path):
+    """Empty history for a window-overlapping target is unresolved, not done."""
     cfg = _cfg(tmp_path, {"600070.SH": "2025-04-10"})
 
     result = backfill_delisted_bars(
@@ -168,5 +169,82 @@ def test_a_symbol_with_no_bars_is_marked_done_but_adds_no_instrument(tmp_path):
     )
 
     assert result["recovered"] == 0
-    assert "600070.SH" in _ingested_symbols(cfg)
+    assert result["empty_symbols"] == 1
+    assert result["failed_symbols"] == 0
+    assert "600070.SH" not in _ingested_symbols(cfg)
     assert _staged(cfg, "instruments", "run-1").is_empty()
+    # The empty target remains a recovery target for the next run.
+    assert "600070.SH" in delisted_backfill_targets(cfg, _START, date.today())
+
+
+def test_fetch_exception_keeps_target_retryable(tmp_path):
+    cfg = _cfg(tmp_path, {"600070.SH": "2025-04-10"})
+
+    def boom(symbol, client):
+        raise ConnectionError("provider down")
+
+    result = backfill_delisted_bars(cfg, "run-1", _START, fetch=boom)
+
+    assert result["failed_symbols"] == 1
+    assert "600070.SH" not in _ingested_symbols(cfg)
+    assert "600070.SH" in delisted_backfill_targets(cfg, _START, date.today())
+
+
+def test_empty_formal_target_kept_retryable(tmp_path):
+    """Formal authority target with an empty vendor response stays retryable."""
+    cfg = _cfg(tmp_path, {})  # no catalogue evidence
+    inst_path = cfg.curated_root / "instruments" / "part-merged.parquet"
+    live = pl.read_parquet(inst_path)
+    formal = pl.DataFrame(
+        {
+            "symbol": ["600071.SH"],
+            "name": ["delisted"],
+            "exchange": ["SH"],
+            "asset_type": ["stock"],
+            "list_date": pl.Series([date(1998, 1, 22)], dtype=pl.Date),
+            "delist_date": pl.Series([date(2025, 4, 10)], dtype=pl.Date),
+            "prev_symbol": [None],
+        }
+    )
+    pl.concat([live, formal], how="diagonal_relaxed").write_parquet(inst_path)
+
+    result = backfill_delisted_bars(
+        cfg,
+        "run-1",
+        _START,
+        fetch=lambda s, c: pl.DataFrame(schema={c: DAILY_BARS_SCHEMA[c] for c in _BAR_COLS}),
+    )
+
+    assert result["empty_symbols"] == 1
+    assert "600071.SH" not in _ingested_symbols(cfg)
+    assert "600071.SH" in delisted_backfill_targets(cfg, _START, date.today())
+
+
+def test_mixed_chunk_preserves_success_and_keeps_empty_exception_retryable(tmp_path):
+    """A successful chunk symbol stays ingested; empty/exception stay targets."""
+    cfg = _cfg(
+        tmp_path,
+        {
+            "600070.SH": "2025-04-10",
+            "600071.SH": "2025-04-10",
+            "600072.SH": "2025-04-10",
+        },
+    )
+
+    def mixed(symbol, client):
+        if symbol == "600070.SH":
+            return _bars(symbol, date(2016, 3, 1), date(2025, 4, 10))
+        if symbol == "600071.SH":
+            return pl.DataFrame(schema={c: DAILY_BARS_SCHEMA[c] for c in _BAR_COLS})
+        raise ConnectionError("provider down")
+
+    result = backfill_delisted_bars(cfg, "run-1", _START, fetch=mixed)
+
+    assert result["recovered"] == 1
+    assert result["empty_symbols"] == 1
+    assert result["failed_symbols"] == 1
+    assert set(_ingested_symbols(cfg)) == {"600070.SH"}
+    staged = _staged(cfg, "daily_bars", "run-1")
+    assert staged["symbol"].unique().to_list() == ["600070.SH"]
+    remaining = delisted_backfill_targets(cfg, _START, date.today())
+    assert remaining == ["600071.SH", "600072.SH"]

--- a/tests/unit/test_delisted_ingest.py
+++ b/tests/unit/test_delisted_ingest.py
@@ -153,7 +153,7 @@ def test_rerun_is_a_noop_once_everything_is_ingested(tmp_path):
 
     result = backfill_delisted_bars(cfg, "run-2", _START, fetch=must_not_be_called)
     assert result["rows_written"] == 0
-    assert "no catalogued delistings" in result["note"]
+    assert "no delisted recovery targets" in result["note"]
 
 
 def test_a_symbol_with_no_bars_is_marked_done_but_adds_no_instrument(tmp_path):

--- a/tests/unit/test_delisted_overlap_contract.py
+++ b/tests/unit/test_delisted_overlap_contract.py
@@ -1,0 +1,337 @@
+"""Formal delisting identity vs last-traded window-overlap contract.
+
+``instruments.delist_date`` is identity/legal authority; it does NOT by itself
+prove a security traded inside ``[start, as_of]``. The last-traded authority
+(observed bars, then catalogue/Sina terminal) decides overlap: a formal
+candidate that stopped trading before ``start`` is EXPECTED_NO_DATA, not
+MISSING_BARS and not a recovery target.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+
+import polars as pl
+import pytest
+
+from ashare_lake.config import Config
+from ashare_lake.steps import delisted
+from ashare_lake.steps.delisted import (
+    _ingested_symbols,
+    backfill_delisted_bars,
+    catalog_path,
+    delisted_backfill_targets,
+    delisted_coverage_report,
+    known_delisted_instruments,
+)
+
+START = date(2023, 8, 7)
+AS_OF = date(2026, 8, 7)
+
+
+def _cfg(tmp_path, *, instruments: dict[str, date], catalog: dict[str, str]) -> Config:
+    cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
+    root = cfg.curated_root / "instruments"
+    root.mkdir(parents=True, exist_ok=True)
+    pl.DataFrame(
+        {
+            "symbol": list(instruments),
+            "list_date": pl.Series([date(1998, 1, 1)] * len(instruments), dtype=pl.Date),
+            "delist_date": pl.Series(list(instruments.values()), dtype=pl.Date),
+        }
+    ).write_parquet(root / "part-merged.parquet")
+    _write_catalog(cfg, catalog)
+    _anchor(cfg)
+    return cfg
+
+
+def _write_catalog(cfg, catalog: dict[str, str]) -> None:
+    path = catalog_path(cfg)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"delisted": catalog, "never_issued": []}))
+
+
+def _anchor(cfg) -> None:
+    part = cfg.curated_root / "daily_bars" / f"trade_date={AS_OF.isoformat()}"
+    part.mkdir(parents=True, exist_ok=True)
+    pl.DataFrame({"symbol": ["600519.SH"], "trade_date": [AS_OF], "volume": [100]}).write_parquet(
+        part / "part-merged.parquet"
+    )
+
+
+def _write_bar(cfg, symbol: str, day: date) -> None:
+    part = cfg.curated_root / "daily_bars" / f"trade_date={day.isoformat()}"
+    part.mkdir(parents=True, exist_ok=True)
+    path = part / "part-merged.parquet"
+    incoming = pl.DataFrame({"symbol": [symbol], "trade_date": [day], "volume": [100]})
+    if path.exists():
+        incoming = pl.concat([pl.read_parquet(path), incoming])
+    incoming.write_parquet(path)
+
+
+def _empty_bars() -> pl.DataFrame:
+    from ashare_lake.domain.schemas import DAILY_BARS_SCHEMA
+
+    cols = [c for c in DAILY_BARS_SCHEMA if c not in ("source", "data_version", "fetched_at")]
+    return pl.DataFrame(schema={c: DAILY_BARS_SCHEMA[c] for c in cols})
+
+
+# --- targeting --------------------------------------------------------------
+
+
+def test_formal_delist_after_start_last_trade_before_start_is_not_target(tmp_path):
+    cfg = _cfg(
+        tmp_path,
+        instruments={"600001.SH": date(2023, 8, 23)},
+        catalog={"600001.SH": "2023-06-13"},  # authoritative terminal before start
+    )
+
+    assert delisted_backfill_targets(cfg, START, AS_OF) == []
+
+
+def test_formal_delist_after_start_with_overlap_is_target(tmp_path):
+    cfg = _cfg(
+        tmp_path,
+        instruments={"600001.SH": date(2023, 8, 23)},
+        catalog={"600001.SH": "2023-10-02"},  # terminal inside window
+    )
+
+    assert delisted_backfill_targets(cfg, START, AS_OF) == ["600001.SH"]
+
+
+def test_formal_no_terminal_evidence_is_still_target(tmp_path):
+    cfg = _cfg(tmp_path, instruments={"600001.SH": date(2023, 8, 23)}, catalog={})
+
+    assert delisted_backfill_targets(cfg, START, AS_OF) == ["600001.SH"]
+
+
+# --- empty-fetch probe resolution -------------------------------------------
+
+
+def test_empty_fetch_probe_prewindow_resolves_no_overlap(tmp_path):
+    cfg = _cfg(
+        tmp_path,
+        instruments={"600001.SH": date(2023, 8, 23)},
+        catalog={},
+    )
+
+    result = backfill_delisted_bars(
+        cfg,
+        "run-1",
+        START,
+        fetch=lambda s, c: _empty_bars(),
+        probe_last=lambda s, c: date(2023, 6, 13),
+    )
+
+    assert result["no_overlap_symbols"] == 1
+    assert result["recovered"] == 0
+    assert result.get("empty_symbols", 0) == 0
+    assert result.get("failed_symbols", 0) == 0
+    assert "600001.SH" not in _ingested_symbols(cfg)
+    # Terminal persisted to the atomic catalogue; next run excludes the symbol.
+    assert delisted_backfill_targets(cfg, START, AS_OF) == []
+
+
+def test_empty_fetch_probe_inwindow_is_inconsistent_unresolved(tmp_path):
+    cfg = _cfg(
+        tmp_path,
+        instruments={"600001.SH": date(2023, 8, 23)},
+        catalog={},
+    )
+
+    result = backfill_delisted_bars(
+        cfg,
+        "run-1",
+        START,
+        fetch=lambda s, c: _empty_bars(),
+        probe_last=lambda s, c: date(2023, 10, 2),
+    )
+
+    assert result["empty_symbols"] == 1
+    assert "600001.SH" not in _ingested_symbols(cfg)
+    assert "600001.SH" in delisted_backfill_targets(cfg, START, AS_OF)
+
+
+def test_empty_fetch_probe_none_is_unresolved_not_never_issued(tmp_path):
+    cfg = _cfg(
+        tmp_path,
+        instruments={"600001.SH": date(2023, 8, 23)},
+        catalog={},
+    )
+
+    result = backfill_delisted_bars(
+        cfg,
+        "run-1",
+        START,
+        fetch=lambda s, c: _empty_bars(),
+        probe_last=lambda s, c: None,
+    )
+
+    assert result["empty_symbols"] == 1
+    assert "600001.SH" not in _ingested_symbols(cfg)
+    assert "600001.SH" in delisted_backfill_targets(cfg, START, AS_OF)
+
+
+def test_empty_fetch_probe_exception_is_unresolved(tmp_path):
+    cfg = _cfg(
+        tmp_path,
+        instruments={"600001.SH": date(2023, 8, 23)},
+        catalog={},
+    )
+
+    def boom(symbol, client):
+        raise ConnectionError("probe down")
+
+    result = backfill_delisted_bars(
+        cfg,
+        "run-1",
+        START,
+        fetch=lambda s, c: _empty_bars(),
+        probe_last=boom,
+    )
+
+    assert result["empty_symbols"] == 1
+    assert "600001.SH" not in _ingested_symbols(cfg)
+
+
+def test_no_overlap_symbol_never_enters_ingested(tmp_path):
+    cfg = _cfg(
+        tmp_path,
+        instruments={"600001.SH": date(2023, 8, 23)},
+        catalog={},
+    )
+
+    backfill_delisted_bars(
+        cfg,
+        "run-1",
+        START,
+        fetch=lambda s, c: _empty_bars(),
+        probe_last=lambda s, c: date(2023, 6, 13),
+    )
+
+    assert "600001.SH" not in _ingested_symbols(cfg)
+    payload = json.loads((cfg.meta_root / "state" / "delisted_catalog.json").read_text())
+    assert payload["delisted"]["600001.SH"] == "2023-06-13"
+
+
+# --- coverage contract ------------------------------------------------------
+
+
+def test_formal_with_bars_and_no_catalog_is_proven_overlap(tmp_path, monkeypatch):
+    """Observed bars prove overlap; absent catalogue must not make it unreconciled."""
+    cfg = _cfg(tmp_path, instruments={"600001.SH": date(2024, 5, 10)}, catalog={})
+    _write_bar(cfg, "600001.SH", date(2024, 5, 10))
+    monkeypatch.setattr("ashare_lake.steps.delisted.pending_codes", lambda cfg: [])
+
+    report = delisted_coverage_report(cfg, START, AS_OF)
+
+    assert report["counts"]["known_formal_candidates"] == 1
+    assert report["counts"]["proven_overlap"] == 1
+    assert report["counts"]["known_delisted_unreconciled"] == 0
+    assert report["counts"]["missing_bars"] == 0
+    assert report["known_coverage_complete"] is True
+
+
+def test_formal_prewindow_terminal_is_expected_no_data_not_missing_bars(tmp_path, monkeypatch):
+    cfg = _cfg(
+        tmp_path,
+        instruments={"600001.SH": date(2023, 8, 23)},
+        catalog={"600001.SH": "2023-06-13"},
+    )
+    monkeypatch.setattr("ashare_lake.steps.delisted.pending_codes", lambda cfg: [])
+
+    report = delisted_coverage_report(cfg, START, AS_OF)
+
+    assert report["counts"]["formal_no_overlap"] == 1
+    assert report["counts"]["missing_bars"] == 0
+    assert report["counts"]["known_overlap_required"] == 0
+    assert report["counts"]["known_delisted_unreconciled"] == 0
+    assert report["known_coverage_complete"] is True
+
+
+def test_formal_required_bars_missing_is_missing_bars(tmp_path, monkeypatch):
+    cfg = _cfg(
+        tmp_path,
+        instruments={"600001.SH": date(2023, 8, 23)},
+        catalog={"600001.SH": "2023-10-02"},
+    )
+    monkeypatch.setattr("ashare_lake.steps.delisted.pending_codes", lambda cfg: [])
+
+    report = delisted_coverage_report(cfg, START, AS_OF)
+
+    assert report["counts"]["known_overlap_required"] == 1
+    assert report["counts"]["missing_bars"] == 1
+    assert report["known_coverage_complete"] is False
+
+
+def test_full_discovery_stays_separate_from_known_coverage(tmp_path):
+    """KNOWN_COVERAGE_COMPLETE can be true while DISCOVERY_COMPLETE is false."""
+    cfg = _cfg(
+        tmp_path,
+        instruments={"600001.SH": date(2024, 5, 10)},
+        catalog={"600001.SH": "2024-05-10"},
+    )
+    _write_bar(cfg, "600001.SH", date(2024, 5, 10))
+
+    report = delisted_coverage_report(cfg, START, AS_OF)
+
+    assert report["known_coverage_complete"] is True
+    assert report["discovery_complete"] is False  # issued-code sweep not done
+    assert report["verified"] is False
+
+
+# --- real state read-only replay (injected frozen evidence) -----------------
+
+REAL_CONFIG = "/Users/luke808/AI/asl-shared-config.toml"
+REAL_MANIFEST = "/Users/luke808/AI/asl-shared/meta/manifest.db"
+# Frozen regression evidence: five formal candidates whose vendor history ends
+# before the window (external exchange evidence; used only in the replay/tests).
+FROZEN_NO_OVERLAP = {
+    "000616.SZ": "2023-06-13",
+    "000671.SZ": "2023-06-13",
+    "002113.SZ": "2023-06-13",
+    "002503.SZ": "2023-06-13",
+    "002504.SZ": "2023-06-13",
+}
+
+
+def test_real_run_readonly_overlap_replay(monkeypatch):
+    """Read-only replay on the real shared root with injected last-traded evidence."""
+    import os
+
+    from ashare_lake.config import load_config
+
+    if not os.path.exists(REAL_MANIFEST):
+        pytest.skip("real shared root not present")
+    cfg = load_config(REAL_CONFIG)
+
+    ingested = _ingested_symbols(cfg)
+    remaining = delisted_backfill_targets(cfg, START, AS_OF)
+    known = known_delisted_instruments(cfg, AS_OF)
+    known_in_window = [s for s, d in known.items() if d >= START]
+    assert len(known_in_window) == 107
+    assert len(ingested) == 102
+    assert set(remaining) == set(FROZEN_NO_OVERLAP)
+
+    # Inject frozen pre-window terminals via the catalogue store (read-only on
+    # real data: the catalogue itself is simulated for the replay).
+    monkeypatch.setattr(
+        delisted,
+        "_read_catalog",
+        lambda config: {"delisted": dict(FROZEN_NO_OVERLAP), "never_issued": []},
+    )
+
+    report = delisted_coverage_report(cfg, START, AS_OF)
+    counts = report["counts"]
+    assert counts["known_formal_candidates"] == 107
+    assert counts["proven_overlap"] == 102
+    assert counts["formal_no_overlap"] == 5
+    assert counts["missing_bars"] == 0
+    assert counts["known_delisted_unreconciled"] == 0
+    assert report["known_coverage_complete"] is True
+    assert report["discovery_complete"] is False  # pending issued-code probes
+    assert report["verified"] is False
+
+    patched_targets = delisted_backfill_targets(cfg, START, AS_OF)
+    assert patched_targets == []  # 102 recovered ingested; 5 proven no-overlap

--- a/tests/unit/test_delisted_routing_recency.py
+++ b/tests/unit/test_delisted_routing_recency.py
@@ -627,6 +627,7 @@ def test_empty_backfill_stays_fail_closed_and_recoverable(tmp_path, monkeypatch)
         "run-1",
         WINDOW_START,
         fetch=lambda s, c: _empty_bars_frame(),
+        probe_last=lambda s, c: None,
     )
     assert first["empty_symbols"] == 1
     assert first["recovered"] == 0

--- a/tests/unit/test_delisted_routing_recency.py
+++ b/tests/unit/test_delisted_routing_recency.py
@@ -23,9 +23,11 @@ from ashare_lake.steps import bars, delisted
 from ashare_lake.steps.common import classify_daily_routing
 from ashare_lake.steps.delisted import (
     catalog_path,
+    delisted_backfill_targets,
     delisted_coverage_report,
     delisted_symbols_in_window,
     known_delisted_instruments,
+    load_delisted_catalog,
     load_live_missing,
     pending_codes,
 )
@@ -147,6 +149,7 @@ def _write_curated_instruments(cfg, rows: list[tuple[str, date | None]]) -> None
     pl.DataFrame(
         {
             "symbol": [row[0] for row in rows],
+            "list_date": pl.Series([None] * len(rows), dtype=pl.Date),
             "delist_date": pl.Series([row[1] for row in rows], dtype=pl.Date),
         }
     ).write_parquet(root / "part-merged.parquet")
@@ -321,7 +324,7 @@ def test_probe_only_recent_terminal_is_quarantined(tmp_path, monkeypatch):
     assert report["verified"] is False
 
 
-def test_known_delisted_quarantined_still_blocks_coverage(tmp_path, monkeypatch):
+def test_known_delisted_quarantined_identity_resolved_but_bars_required(tmp_path, monkeypatch):
     cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
     _write_curated_instruments(cfg, [("600001.SH", date(2026, 7, 14))])
     _write_catalog(cfg, {"600001.SH": "2026-07-17"})  # probe last within 30 days
@@ -333,10 +336,13 @@ def test_known_delisted_quarantined_still_blocks_coverage(tmp_path, monkeypatch)
 
     assert report["counts"]["known_delisted_instruments"] == 1
     assert report["counts"]["known_delisted_in_window"] == 1
-    assert report["counts"]["recent_quarantined"] == 1
-    entry = report["samples"]["recent_quarantined"][0]
+    # Formal authority resolves identity: not a probe-only quarantine blocker,
+    # but the missing bars still fail the gate.
+    assert report["counts"]["recent_quarantined"] == 0
+    assert report["counts"]["catalog_recent_quarantined"] == 1
+    assert report["counts"]["missing_bars"] == 1
+    entry = report["samples"]["catalog_recent_quarantined"][0]
     assert entry["symbol"] == "600001.SH"
-    assert entry["basis"] == "known_delisted_quarantined"
     assert report["verified"] is False
 
 
@@ -445,8 +451,9 @@ def test_frozen_replay_real_runtime_semantics(tmp_path, monkeypatch):
     )
     assert recent == ["000004.SZ", "002808.SZ", "002898.SZ", "300029.SZ"]
 
-    # Coverage gate view with the real 30-day rule: 4 recency-edge names are
-    # quarantined at the catalogue level, keeping the gate fail-closed.
+    # Coverage gate view with the real 30-day rule: the 4 recency-edge names
+    # are quarantined at the catalogue level (diagnostic), but formal authority
+    # resolves identity — their missing bars fail the gate.
     cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
     _write_curated_instruments(cfg, [(sym, spans[sym][1]) for sym in spans])
     _write_catalog(cfg, {sym: spans[sym][1].isoformat() for sym in spans})
@@ -458,12 +465,143 @@ def test_frozen_replay_real_runtime_semantics(tmp_path, monkeypatch):
     assert counts["known_delisted_instruments"] == 336
     assert counts["known_delisted_in_window"] == 107
     assert counts["expected_no_data"] == 229
-    assert counts["recent_quarantined"] == 4
+    assert counts["recent_quarantined"] == 0  # all 336 carry formal authority
+    assert counts["catalog_recent_quarantined"] == 4  # diagnostic only
     assert counts["known_delisted_unreconciled"] == 0
-    assert counts["missing_bars"] == 103
+    assert counts["missing_bars"] == 107
     assert report["verified"] is False
-    quarantined_symbols = {s["symbol"] for s in report["samples"]["recent_quarantined"]}
+    quarantined_symbols = {s["symbol"] for s in report["samples"]["catalog_recent_quarantined"]}
     assert quarantined_symbols == set(recent)
-    assert all(
-        s["basis"] == "known_delisted_quarantined" for s in report["samples"]["recent_quarantined"]
+
+    # Recovery ownership: formal authority makes every in-window delisting a
+    # backfill target immediately (107), even under catalogue quarantine; no
+    # probe-only blocker exists among these 336.
+    targets = delisted_backfill_targets(cfg, WINDOW_START, WINDOW_END)
+    assert len(targets) == 107
+    assert set(targets) == set(routing.excluded_delegated_delisted)
+
+    # Coverage closure: once every formal target has recovered bars (including
+    # the 4 catalogue-quarantined names), the gate verifies.
+    for symbol, (_list_date, formal) in spans.items():
+        if formal >= WINDOW_START:
+            _write_bar(cfg, symbol, formal)
+    covered = delisted_coverage_report(cfg, WINDOW_START, WINDOW_END)
+    covered_counts = covered["counts"]
+    assert covered_counts["missing_bars"] == 0
+    assert covered_counts["recent_quarantined"] == 0
+    assert covered_counts["proven_overlap"] == 107
+    assert covered["verified"] is True
+
+
+# --- backfill target closure ------------------------------------------------
+
+
+def test_formal_recent_delisting_is_backfill_target(tmp_path):
+    """The critical regression: formal authority beats catalogue quarantine."""
+    cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
+    _write_curated_instruments(cfg, [("600001.SH", date(2026, 7, 14))])
+    _write_catalog(cfg, {"600001.SH": "2026-07-17"})  # probe last within 30 days
+    _write_anchor_bar(cfg)
+
+    assert "600001.SH" in load_live_missing(cfg), "catalogue classification = quarantine"
+    assert "600001.SH" not in load_delisted_catalog(cfg), "not definite at catalogue level"
+    assert known_delisted_instruments(cfg, WINDOW_END) == {"600001.SH": date(2026, 7, 14)}
+    assert delisted_backfill_targets(cfg, WINDOW_START, WINDOW_END) == ["600001.SH"]
+
+
+def test_probe_only_recent_is_not_backfill_target(tmp_path):
+    cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
+    _write_catalog(cfg, {"600099.SH": "2026-07-20"})  # probe-only, within 30 days
+    _write_anchor_bar(cfg)
+
+    assert delisted_backfill_targets(cfg, WINDOW_START, WINDOW_END) == []
+
+
+def test_formal_pre_window_is_not_backfill_target(tmp_path):
+    cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
+    _write_curated_instruments(cfg, [("600002.SH", date(2006, 4, 6))])
+    _write_anchor_bar(cfg)
+
+    assert delisted_backfill_targets(cfg, WINDOW_START, WINDOW_END) == []
+
+
+def test_formal_future_relative_as_of_is_not_backfill_target(tmp_path):
+    cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
+    _write_curated_instruments(cfg, [("600004.SH", date(2026, 9, 1))])
+    _write_anchor_bar(cfg)
+
+    assert delisted_backfill_targets(cfg, WINDOW_START, WINDOW_END) == []
+
+
+def test_catalog_definite_is_backfill_target(tmp_path):
+    cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
+    _write_catalog(cfg, {"600005.SH": "2024-05-10"})
+    _write_anchor_bar(cfg)
+
+    assert delisted_backfill_targets(cfg, WINDOW_START, WINDOW_END) == ["600005.SH"]
+
+
+def test_duplicate_authority_yields_single_backfill_target(tmp_path):
+    cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
+    _write_curated_instruments(cfg, [("600006.SH", date(2024, 5, 10))])
+    _write_catalog(cfg, {"600006.SH": "2024-05-10"})
+    _write_anchor_bar(cfg)
+
+    assert delisted_backfill_targets(cfg, WINDOW_START, WINDOW_END) == ["600006.SH"]
+
+
+def test_already_ingested_is_not_backfill_target(tmp_path):
+    cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
+    _write_curated_instruments(cfg, [("600001.SH", date(2026, 7, 14))])
+    _write_catalog(cfg, {"600001.SH": "2026-07-17"})
+    _write_anchor_bar(cfg)
+    state = cfg.meta_root / "state" / "delisted_ingested.json"
+    state.parent.mkdir(parents=True, exist_ok=True)
+    state.write_text(json.dumps({"completed": ["600001.SH"]}))
+
+    assert delisted_backfill_targets(cfg, WINDOW_START, WINDOW_END) == []
+
+
+def _fake_sina_bars(symbol: str, client=None) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "symbol": [symbol, symbol],
+            "trade_date": [date(2026, 7, 10), date(2026, 7, 14)],
+            "open": [10.0, 10.5],
+            "high": [10.8, 11.0],
+            "low": [9.8, 10.2],
+            "close": [10.4, 10.9],
+            "volume": [1_000_000, 900_000],
+            "amount": [10_400_000.0, 9_810_000.0],
+        }
     )
+
+
+def test_backfill_recovers_formal_only_target(cfg):
+    """backfill_delisted_bars reaches a catalogue-quarantined formal delisting."""
+    init_data_layout(cfg)
+    manifest = Manifest(cfg.manifest_path)
+    run_id = manifest.start_run("test")
+    _write_curated_instruments(cfg, [("600001.SH", date(2026, 7, 14))])
+    _write_catalog(cfg, {"600001.SH": "2026-07-17"})  # quarantined at catalogue level
+    _write_anchor_bar(cfg)
+
+    result = delisted.backfill_delisted_bars(
+        cfg,
+        run_id,
+        WINDOW_START,
+        fetch=_fake_sina_bars,
+    )
+
+    assert result["symbols"] == 1
+    assert result["recovered"] == 1
+    assert _staged_daily_symbols(cfg, run_id) == {"600001.SH"}
+    # The recovered name is marked ingested: a re-run is a no-op.
+    again = delisted.backfill_delisted_bars(
+        cfg,
+        run_id,
+        WINDOW_START,
+        fetch=_fake_sina_bars,
+    )
+    assert again.get("symbols", 0) == 0
+    assert "no delisted recovery targets" in again.get("note", "")

--- a/tests/unit/test_delisted_routing_recency.py
+++ b/tests/unit/test_delisted_routing_recency.py
@@ -1,0 +1,471 @@
+"""Delist-aware routing + recency contract on the current upstream.
+
+Ownership contract under test: for a historical window ``[start, end]`` the
+generic TDX/EastMoney path only receives symbols active through ``end``;
+formally delisted symbols (instrument authority) are known-delisted with an
+explicit state; probe-only recent terminals stay quarantined (30-day rule) and
+keep coverage fail-closed.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from ashare_lake.config import Config, load_config
+from ashare_lake.config.bootstrap import path_for_toml
+from ashare_lake.orchestrator.manifest import Manifest
+from ashare_lake.steps import bars, delisted
+from ashare_lake.steps.common import classify_daily_routing
+from ashare_lake.steps.delisted import (
+    catalog_path,
+    delisted_coverage_report,
+    delisted_symbols_in_window,
+    known_delisted_instruments,
+    load_live_missing,
+    pending_codes,
+)
+from ashare_lake.storage import StagingWriter
+from ashare_lake.storage.layout import init_data_layout
+
+WINDOW_START = date(2023, 8, 7)
+WINDOW_END = date(2026, 8, 7)
+
+LIVE = "600519.SH"
+ACTIVE_AT_END = "000001.SZ"
+A_SYMBOL = "600002.SH"  # delisted before window start
+B_SYMBOL = "600070.SH"  # delisted inside the window
+FUTURE_LISTING = "688001.SH"  # listed after window end
+
+
+def _spans() -> dict[str, tuple[date | None, date | None]]:
+    return {
+        LIVE: (date(2001, 8, 27), None),
+        ACTIVE_AT_END: (date(1991, 4, 3), date(2027, 6, 1)),
+        A_SYMBOL: (date(1998, 1, 22), date(2006, 4, 6)),
+        B_SYMBOL: (date(1997, 3, 1), date(2024, 5, 10)),
+        FUTURE_LISTING: (date(2027, 1, 1), None),
+    }
+
+
+def _instrument_rows() -> list[dict]:
+    spans = _spans()
+    return [
+        {
+            "symbol": sym,
+            "name": f"Mock-{sym}",
+            "exchange": sym.split(".")[1],
+            "asset_type": "stock",
+            "list_date": spans[sym][0],
+            "delist_date": spans[sym][1],
+            "prev_symbol": None,
+        }
+        for sym in spans
+    ]
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    cfg_path = tmp_path / "test.toml"
+    cfg_path.write_text(
+        f"""
+[data]
+root = "{path_for_toml(tmp_path / "data")}"
+
+[orchestrator]
+workers = 1
+batch_size = 100
+
+[tdx_protocol]
+allow_mock = true
+"""
+    )
+    return load_config(cfg_path)
+
+
+def _write_instruments(cfg, rows: list[dict]) -> None:
+    df = pl.DataFrame(
+        rows,
+        schema={
+            "symbol": pl.Utf8,
+            "name": pl.Utf8,
+            "exchange": pl.Utf8,
+            "asset_type": pl.Utf8,
+            "list_date": pl.Date,
+            "delist_date": pl.Date,
+            "prev_symbol": pl.Utf8,
+        },
+    )
+    out_dir = cfg.staging_root / "instruments" / "run_id=test"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(out_dir / "part-0.parquet", compression="zstd")
+
+
+def _staged_daily_symbols(cfg, run_id: str) -> set[str]:
+    files = StagingWriter(cfg.staging_root).list_run_files("daily_bars", run_id)
+    if not files:
+        return set()
+    return set(
+        pl.scan_parquet([str(f) for f in files])
+        .select("symbol")
+        .unique()
+        .collect()["symbol"]
+        .to_list()
+    )
+
+
+def _start_failed_batch(
+    manifest: Manifest,
+    run_id: str,
+    batch_id: str,
+    symbols: list[str],
+) -> None:
+    manifest.start_batch(
+        run_id,
+        batch_id,
+        task_id="daily_bars",
+        dataset="daily_bars",
+        symbols=symbols,
+        window_start=WINDOW_START.isoformat(),
+        window_end=WINDOW_END.isoformat(),
+    )
+    manifest.finish_batch(
+        run_id,
+        batch_id,
+        "failed",
+        error_message="daily_bars: TDX returned no bars (set [tdx_protocol].allow_mock for tests)",
+    )
+
+
+def _write_curated_instruments(cfg, rows: list[tuple[str, date | None]]) -> None:
+    root = cfg.curated_root / "instruments"
+    root.mkdir(parents=True, exist_ok=True)
+    pl.DataFrame(
+        {
+            "symbol": [row[0] for row in rows],
+            "delist_date": pl.Series([row[1] for row in rows], dtype=pl.Date),
+        }
+    ).write_parquet(root / "part-merged.parquet")
+
+
+def _write_anchor_bar(cfg) -> None:
+    """Anchor the catalogue reference date to the frozen window end."""
+    part = cfg.curated_root / "daily_bars" / f"trade_date={WINDOW_END.isoformat()}"
+    part.mkdir(parents=True, exist_ok=True)
+    pl.DataFrame(
+        {"symbol": ["600519.SH"], "trade_date": [WINDOW_END], "volume": [100]}
+    ).write_parquet(part / "part-merged.parquet")
+
+
+def _write_bar(cfg, symbol: str, *days: date, volume: int = 100) -> None:
+    for day in days:
+        part = cfg.curated_root / "daily_bars" / f"trade_date={day.isoformat()}"
+        part.mkdir(parents=True, exist_ok=True)
+        path = part / "part-merged.parquet"
+        incoming = pl.DataFrame({"symbol": [symbol], "trade_date": [day], "volume": [volume]})
+        if path.exists():
+            incoming = pl.concat([pl.read_parquet(path), incoming])
+        incoming.write_parquet(path)
+
+
+def _write_catalog(cfg, catalog: dict[str, str]) -> None:
+    path = catalog_path(cfg)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"delisted": catalog, "never_issued": [], "version": 1}))
+
+
+# --- routing -----------------------------------------------------------------
+
+
+def test_classifier_routes_a_b_active_and_future():
+    spans = _spans()
+    routing = classify_daily_routing(list(spans), spans, WINDOW_START, WINDOW_END)
+    assert routing.included == [LIVE, ACTIVE_AT_END]
+    assert routing.excluded_expected_no_data == [A_SYMBOL, FUTURE_LISTING]
+    assert routing.excluded_delegated_delisted == [B_SYMBOL]
+    assert routing.excluded_future_listing == [FUTURE_LISTING]
+
+
+def test_classifier_unknown_span_treated_active_never_silently_dropped():
+    routing = classify_daily_routing(["999999.SH"], {}, WINDOW_START, WINDOW_END)
+    assert routing.included == ["999999.SH"]
+    assert routing.excluded == []
+
+
+def test_classifier_delist_exactly_at_end_is_delegated():
+    spans = {"600070.SH": (date(1997, 3, 1), WINDOW_END)}
+    routing = classify_daily_routing(["600070.SH"], spans, WINDOW_START, WINDOW_END)
+    assert routing.excluded_delegated_delisted == ["600070.SH"]
+
+
+def test_fresh_backfill_fetches_only_generic_symbols(cfg):
+    init_data_layout(cfg)
+    run_id = Manifest(cfg.manifest_path).start_run("test")
+    _write_instruments(cfg, _instrument_rows())
+    cfg._backfill = True
+    cfg._backfill_start = WINDOW_START
+    cfg._backfill_end = WINDOW_END
+
+    out = bars.step_daily_bars(cfg, WINDOW_END, run_id, {})
+
+    assert _staged_daily_symbols(cfg, run_id) == {LIVE, ACTIVE_AT_END}
+    assert out["context_updates"]["daily_bars_routing"] == {
+        "generic_included": 2,
+        "excluded_expected_no_data": 2,
+        "excluded_delegated_delisted": 1,
+        "excluded_future_listing": 1,
+    }
+    findings = out["context_updates"]["audit_findings"]
+    assert any(f["check"] == "daily_bars_delist_aware_routing" for f in findings)
+
+
+# --- retry -------------------------------------------------------------------
+
+
+def test_retry_all_delisted_batch_resolves_without_vendor(cfg):
+    init_data_layout(cfg)
+    manifest = Manifest(cfg.manifest_path)
+    run_id = manifest.start_run("test")
+    _write_instruments(cfg, [r for r in _instrument_rows() if r["symbol"] in (A_SYMBOL, B_SYMBOL)])
+    batch_id = "2023-08-07_2026-08-07-batch-0"
+    symbols = [A_SYMBOL, B_SYMBOL]
+    _start_failed_batch(manifest, run_id, batch_id, symbols)
+
+    out = bars.step_daily_bars(
+        cfg,
+        WINDOW_END,
+        run_id,
+        {"_retry_batch_specs": [(batch_id, symbols, WINDOW_START, WINDOW_END)]},
+    )
+
+    row = manifest.get_batch(run_id, batch_id)
+    assert row["status"] == "success"
+    assert row["rows_written"] == 0
+    assert "ROUTED_OUT_OF_GENERIC" in row["error_message"]
+    assert "expected_no_data=1" in row["error_message"]
+    assert "delegated_delisted=1" in row["error_message"]
+    # Original batch identity/symbol provenance retained; no vendor rows.
+    assert json.loads(row["symbols_json"]) == symbols
+    assert _staged_daily_symbols(cfg, run_id) == set()
+    assert manifest.get_batch(run_id, f"{batch_id}-delegated") is None
+    assert out["context_updates"]["daily_bars_routing"]["generic_included"] == 0
+
+
+def test_retry_mixed_batch_fetches_generic_only_and_records_delegated(cfg):
+    init_data_layout(cfg)
+    manifest = Manifest(cfg.manifest_path)
+    run_id = manifest.start_run("test")
+    _write_instruments(
+        cfg, [r for r in _instrument_rows() if r["symbol"] in (LIVE, A_SYMBOL, B_SYMBOL)]
+    )
+    batch_id = "2023-08-07_2026-08-07-batch-0"
+    symbols = [LIVE, A_SYMBOL, B_SYMBOL]
+    _start_failed_batch(manifest, run_id, batch_id, symbols)
+
+    out = bars.step_daily_bars(
+        cfg,
+        WINDOW_END,
+        run_id,
+        {"_retry_batch_specs": [(batch_id, symbols, WINDOW_START, WINDOW_END)]},
+    )
+
+    assert _staged_daily_symbols(cfg, run_id) == {LIVE}
+    row = manifest.get_batch(run_id, batch_id)
+    assert row["status"] == "success"
+    assert json.loads(row["symbols_json"]) == [LIVE]
+    sibling = manifest.get_batch(run_id, f"{batch_id}-delegated")
+    assert sibling is not None
+    assert sibling["status"] == "success"
+    assert sibling["rows_written"] == 0
+    assert "ROUTED_OUT_OF_GENERIC" in sibling["error_message"]
+    assert set(json.loads(sibling["symbols_json"])) == {A_SYMBOL, B_SYMBOL}
+    counts = out["context_updates"]["daily_bars_routing"]
+    assert counts["generic_included"] == 1
+    assert counts["excluded_expected_no_data"] == 1
+    assert counts["excluded_delegated_delisted"] == 1
+
+
+# --- discovery live-set ------------------------------------------------------
+
+
+def test_pending_codes_does_not_mask_delisted_as_live(cfg):
+    init_data_layout(cfg)
+    _write_instruments(
+        cfg, [r for r in _instrument_rows() if r["symbol"] in (LIVE, A_SYMBOL)]
+    )
+
+    pending = pending_codes(cfg)
+
+    assert LIVE not in pending, "a genuinely active instrument stays excluded from discovery"
+    assert A_SYMBOL in pending, "a known delisted symbol must become a discovery candidate"
+
+
+# --- recency contract (real runtime semantics, 30-day rule kept) -------------
+
+
+def test_probe_only_recent_terminal_is_quarantined(tmp_path, monkeypatch):
+    cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
+    _write_catalog(cfg, {"600099.SH": "2026-07-20"})  # probe-only, inside 30-day window
+    _write_anchor_bar(cfg)
+    monkeypatch.setattr("ashare_lake.steps.delisted.pending_codes", lambda cfg: [])
+
+    live_missing = load_live_missing(cfg)
+    assert "600099.SH" in live_missing, "probe-only recent terminal stays quarantined"
+    assert "600099.SH" not in known_delisted_instruments(cfg, WINDOW_END)
+
+    report = delisted_coverage_report(cfg, WINDOW_START, WINDOW_END)
+    assert report["counts"]["recent_quarantined"] == 1
+    assert report["samples"]["recent_quarantined"][0]["basis"] == "probe_only"
+    assert report["verified"] is False
+
+
+def test_known_delisted_quarantined_still_blocks_coverage(tmp_path, monkeypatch):
+    cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
+    _write_curated_instruments(cfg, [("600001.SH", date(2026, 7, 14))])
+    _write_catalog(cfg, {"600001.SH": "2026-07-17"})  # probe last within 30 days
+    _write_anchor_bar(cfg)
+    monkeypatch.setattr("ashare_lake.steps.delisted.pending_codes", lambda cfg: [])
+
+    assert known_delisted_instruments(cfg, WINDOW_END) == {"600001.SH": date(2026, 7, 14)}
+    report = delisted_coverage_report(cfg, WINDOW_START, WINDOW_END)
+
+    assert report["counts"]["known_delisted_instruments"] == 1
+    assert report["counts"]["known_delisted_in_window"] == 1
+    assert report["counts"]["recent_quarantined"] == 1
+    entry = report["samples"]["recent_quarantined"][0]
+    assert entry["symbol"] == "600001.SH"
+    assert entry["basis"] == "known_delisted_quarantined"
+    assert report["verified"] is False
+
+
+def test_known_delisted_covered_becomes_verified(tmp_path, monkeypatch):
+    cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
+    _write_curated_instruments(cfg, [("600002.SH", date(2024, 5, 10))])
+    _write_catalog(cfg, {"600002.SH": "2024-05-10"})
+    _write_bar(cfg, "600002.SH", date(2023, 9, 1), date(2024, 5, 10))
+    _write_anchor_bar(cfg)
+    monkeypatch.setattr("ashare_lake.steps.delisted.pending_codes", lambda cfg: [])
+
+    report = delisted_coverage_report(cfg, WINDOW_START, WINDOW_END)
+
+    assert report["counts"]["known_delisted_in_window"] == 1
+    assert report["counts"]["proven_overlap"] == 1
+    assert report["counts"]["missing_bars"] == 0
+    assert report["counts"]["recent_quarantined"] == 0
+    assert report["verified"] is True
+
+
+def test_known_delisted_with_missing_bars_is_not_verified(tmp_path, monkeypatch):
+    cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
+    _write_curated_instruments(cfg, [("600003.SH", date(2024, 6, 3))])
+    _write_catalog(cfg, {"600003.SH": "2024-06-03"})
+    _write_anchor_bar(cfg)
+    monkeypatch.setattr("ashare_lake.steps.delisted.pending_codes", lambda cfg: [])
+
+    report = delisted_coverage_report(cfg, WINDOW_START, WINDOW_END)
+
+    assert report["counts"]["missing_bars"] == 1
+    assert report["counts"]["recent_quarantined"] == 0
+    assert report["counts"]["known_delisted_unreconciled"] == 0
+    assert report["verified"] is False
+
+
+def test_known_delisted_unreconciled_when_catalog_lacks_it(tmp_path, monkeypatch):
+    cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
+    _write_curated_instruments(cfg, [("600004.SH", date(2024, 6, 3))])
+    _write_catalog(cfg, {})  # discovery never filed it
+    _write_anchor_bar(cfg)
+    monkeypatch.setattr("ashare_lake.steps.delisted.pending_codes", lambda cfg: [])
+
+    report = delisted_coverage_report(cfg, WINDOW_START, WINDOW_END)
+
+    assert report["counts"]["known_delisted_unreconciled"] == 1
+    assert report["samples"]["known_delisted_unreconciled"][0]["reason"] == "not_discovered"
+    assert report["verified"] is False
+
+
+def test_classify_catalog_keeps_30_day_quarantine():
+    """Regression: LIVE_RECENCY_DAYS stays 30 in runtime semantics."""
+    assert delisted.LIVE_RECENCY_DAYS == 30
+
+
+# --- window semantics --------------------------------------------------------
+
+
+def test_delisted_symbols_in_window_requires_b_and_skips_a(tmp_path):
+    cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
+    _write_catalog(
+        cfg,
+        {
+            A_SYMBOL: "2006-04-06",
+            B_SYMBOL: "2024-05-10",
+        },
+    )
+    _write_anchor_bar(cfg)
+
+    assert delisted_symbols_in_window(cfg, WINDOW_START) == [B_SYMBOL]
+
+
+# --- frozen classification replay (read-only, real runtime semantics) --------
+
+REAL_TSV = Path(
+    "/Users/luke808/AI/shared-asl-init-failed-daily-bars-ab-classification-0280a169-v01.tsv"
+)
+
+
+def test_frozen_replay_real_runtime_semantics(tmp_path, monkeypatch):
+    """Frozen 336 population under the exact runtime contract (no rule disabled)."""
+    if not REAL_TSV.exists():
+        pytest.skip("real classification TSV not present on this machine")
+    spans: dict[str, tuple[date | None, date | None]] = {}
+    for line in REAL_TSV.read_text(encoding="utf-8").splitlines():
+        if not line or line.startswith("#") or line.startswith("symbol"):
+            continue
+        symbol, _cls, _basis, list_date, delist_date = line.split("\t")
+        spans[symbol] = (date.fromisoformat(list_date), date.fromisoformat(delist_date))
+    assert len(spans) == 336
+
+    # Routing view: instrument authority is decisive for every known delisting.
+    routing = classify_daily_routing(list(spans), spans, WINDOW_START, WINDOW_END)
+    assert routing.included == []
+    assert len(routing.excluded_expected_no_data) == 229
+    assert len(routing.excluded_delegated_delisted) == 107
+    assert routing.excluded_future_listing == []
+
+    # Recency-edge regression expectation derived from the frozen TSV:
+    # probe-only semantics would quarantine delist dates within 30 days of the
+    # window end (2026-07-08..2026-08-07). Runtime must NOT hardcode this list.
+    cutoff = WINDOW_END - timedelta(days=delisted.LIVE_RECENCY_DAYS)
+    recent = sorted(
+        sym
+        for sym, (_list, delist_date) in spans.items()
+        if WINDOW_START <= delist_date <= WINDOW_END and delist_date > cutoff
+    )
+    assert recent == ["000004.SZ", "002808.SZ", "002898.SZ", "300029.SZ"]
+
+    # Coverage gate view with the real 30-day rule: 4 recency-edge names are
+    # quarantined at the catalogue level, keeping the gate fail-closed.
+    cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
+    _write_curated_instruments(
+        cfg, [(sym, spans[sym][1]) for sym in spans]
+    )
+    _write_catalog(cfg, {sym: spans[sym][1].isoformat() for sym in spans})
+    _write_anchor_bar(cfg)
+    monkeypatch.setattr("ashare_lake.steps.delisted.pending_codes", lambda cfg: [])
+
+    report = delisted_coverage_report(cfg, WINDOW_START, WINDOW_END)
+    counts = report["counts"]
+    assert counts["known_delisted_instruments"] == 336
+    assert counts["known_delisted_in_window"] == 107
+    assert counts["expected_no_data"] == 229
+    assert counts["recent_quarantined"] == 4
+    assert counts["known_delisted_unreconciled"] == 0
+    assert counts["missing_bars"] == 103
+    assert report["verified"] is False
+    quarantined_symbols = {s["symbol"] for s in report["samples"]["recent_quarantined"]}
+    assert quarantined_symbols == set(recent)
+    assert all(s["basis"] == "known_delisted_quarantined" for s in report["samples"]["recent_quarantined"])

--- a/tests/unit/test_delisted_routing_recency.py
+++ b/tests/unit/test_delisted_routing_recency.py
@@ -18,6 +18,7 @@ import pytest
 
 from ashare_lake.config import Config, load_config
 from ashare_lake.config.bootstrap import path_for_toml
+from ashare_lake.domain.schemas import DAILY_BARS_SCHEMA
 from ashare_lake.orchestrator.manifest import Manifest
 from ashare_lake.steps import bars, delisted
 from ashare_lake.steps.common import classify_daily_routing
@@ -605,3 +606,50 @@ def test_backfill_recovers_formal_only_target(cfg):
     )
     assert again.get("symbols", 0) == 0
     assert "no delisted recovery targets" in again.get("note", "")
+
+
+def _empty_bars_frame() -> pl.DataFrame:
+    cols = [c for c in DAILY_BARS_SCHEMA if c not in ("source", "data_version", "fetched_at")]
+    return pl.DataFrame(schema={c: DAILY_BARS_SCHEMA[c] for c in cols})
+
+
+def test_empty_backfill_stays_fail_closed_and_recoverable(tmp_path, monkeypatch):
+    """Empty response: not ingested, gate fail-closed, next run still targets."""
+    cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
+    init_data_layout(cfg)
+    _write_curated_instruments(cfg, [("600001.SH", date(2026, 7, 14))])
+    _write_catalog(cfg, {"600001.SH": "2026-07-17"})
+    _write_anchor_bar(cfg)
+    monkeypatch.setattr("ashare_lake.steps.delisted.pending_codes", lambda cfg: [])
+
+    first = delisted.backfill_delisted_bars(
+        cfg,
+        "run-1",
+        WINDOW_START,
+        fetch=lambda s, c: _empty_bars_frame(),
+    )
+    assert first["empty_symbols"] == 1
+    assert first["recovered"] == 0
+    assert "600001.SH" not in delisted._ingested_symbols(cfg)
+    assert "600001.SH" in delisted_backfill_targets(cfg, WINDOW_START, WINDOW_END)
+
+    report = delisted_coverage_report(cfg, WINDOW_START, WINDOW_END)
+    assert report["verified"] is False
+    assert report["counts"]["missing_bars"] == 1
+
+    # A later run recovers valid bars: staged, ingested, coverage can verify.
+    second = delisted.backfill_delisted_bars(
+        cfg,
+        "run-2",
+        WINDOW_START,
+        fetch=_fake_sina_bars,
+    )
+    assert second["recovered"] == 1
+    assert "600001.SH" in delisted._ingested_symbols(cfg)
+    assert _staged_daily_symbols(cfg, "run-2") == {"600001.SH"}
+    # Compact would land the recovered bars in curated; simulate it.
+    _write_bar(cfg, "600001.SH", date(2026, 7, 14))
+    covered = delisted_coverage_report(cfg, WINDOW_START, WINDOW_END)
+    assert covered["counts"]["missing_bars"] == 0
+    assert covered["counts"]["proven_overlap"] == 1
+    assert covered["verified"] is True

--- a/tests/unit/test_delisted_routing_recency.py
+++ b/tests/unit/test_delisted_routing_recency.py
@@ -294,9 +294,7 @@ def test_retry_mixed_batch_fetches_generic_only_and_records_delegated(cfg):
 
 def test_pending_codes_does_not_mask_delisted_as_live(cfg):
     init_data_layout(cfg)
-    _write_instruments(
-        cfg, [r for r in _instrument_rows() if r["symbol"] in (LIVE, A_SYMBOL)]
-    )
+    _write_instruments(cfg, [r for r in _instrument_rows() if r["symbol"] in (LIVE, A_SYMBOL)])
 
     pending = pending_codes(cfg)
 
@@ -450,9 +448,7 @@ def test_frozen_replay_real_runtime_semantics(tmp_path, monkeypatch):
     # Coverage gate view with the real 30-day rule: 4 recency-edge names are
     # quarantined at the catalogue level, keeping the gate fail-closed.
     cfg = Config(data_root=tmp_path / "data", sources={"sina": True})
-    _write_curated_instruments(
-        cfg, [(sym, spans[sym][1]) for sym in spans]
-    )
+    _write_curated_instruments(cfg, [(sym, spans[sym][1]) for sym in spans])
     _write_catalog(cfg, {sym: spans[sym][1].isoformat() for sym in spans})
     _write_anchor_bar(cfg)
     monkeypatch.setattr("ashare_lake.steps.delisted.pending_codes", lambda cfg: [])
@@ -468,4 +464,6 @@ def test_frozen_replay_real_runtime_semantics(tmp_path, monkeypatch):
     assert report["verified"] is False
     quarantined_symbols = {s["symbol"] for s in report["samples"]["recent_quarantined"]}
     assert quarantined_symbols == set(recent)
-    assert all(s["basis"] == "known_delisted_quarantined" for s in report["samples"]["recent_quarantined"])
+    assert all(
+        s["basis"] == "known_delisted_quarantined" for s in report["samples"]["recent_quarantined"]
+    )

--- a/tests/unit/test_historical_validity.py
+++ b/tests/unit/test_historical_validity.py
@@ -43,6 +43,8 @@ def _survivorship(*, verified: bool) -> dict:
         "verified": verified,
         "counts": {
             "pending_probe": 0 if verified else 2,
+            "recent_quarantined": 0,
+            "known_delisted_unreconciled": 0,
             "missing_bars": 0,
             "unknown_overlap": 0,
             "terminal_mismatch": 0,

--- a/tests/unit/test_resume_ledger.py
+++ b/tests/unit/test_resume_ledger.py
@@ -1,0 +1,413 @@
+"""Ledger correctness for init resume: supersession + current-phase authority.
+
+Two defects under test:
+
+* Bug A — historical ``phase_results`` snapshots permanently poisoned the final
+  init status even after their batches were recovered; final status must derive
+  from CURRENT manifest batch state.
+* Bug B — a successfully retried non-worker step left its old failed/stale
+  batch permanently incomplete; the retry must supersede the old attempt while
+  keeping it auditable.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import date
+
+import pytest
+
+import ashare_lake.orchestrator.engine as eng_mod
+from ashare_lake.config import Config
+from ashare_lake.orchestrator.compact_gate import compact_allowed
+from ashare_lake.orchestrator.engine import JobEngine
+from ashare_lake.orchestrator.init_phases import (
+    current_phase_statuses,
+    init_run_complete,
+    needs_finalize,
+    step_incomplete,
+    step_succeeded,
+)
+from ashare_lake.orchestrator.manifest import Manifest
+from ashare_lake.orchestrator.registry import StepEntry
+from ashare_lake.storage.layout import init_data_layout
+
+_PHASES = [
+    "phase1_reference",
+    "phase2c_daily_bars_backfill",
+    "phase3_index_and_status",
+    "phase4_finalize",
+]
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    return Config(
+        data_root=tmp_path / "data",
+        init_phases=_PHASES,
+        tdx_allow_mock=True,
+    )
+
+
+def _stub_get_step(monkeypatch, *, fail: set[str] | None = None, running: set[str] | None = None):
+    """Replace all steps with offline stubs; worker flags off so retry is a step."""
+    fail = fail or set()
+    running = running or set()
+
+    def _fn(name: str):
+        def _call(config, trade_date, run_id, context):
+            if name in fail:
+                raise RuntimeError(f"simulated {name} failure")
+            return {"rows_read": 1, "rows_written": 1}
+
+        return StepEntry(fn=_call, group="test", requires_workers=False)
+
+    monkeypatch.setattr(eng_mod, "get_step", _fn)
+
+
+def _mk_run(manifest: Manifest, *, historical_failure: bool = False) -> str:
+    meta = {"phases": _PHASES, "trade_date": "2024-06-28"}
+    if historical_failure:
+        meta["phase_results"] = [
+            {"phase": "phase1_reference", "status": "success"},
+            {"phase": "phase2c_daily_bars_backfill", "status": "failed"},
+        ]
+    return manifest.start_run("init", meta)
+
+
+def _add_batch(
+    manifest: Manifest,
+    run_id: str,
+    batch_id: str,
+    dataset: str,
+    status: str,
+    *,
+    error: str | None = None,
+) -> None:
+    manifest.start_batch(run_id, batch_id, task_id=dataset, dataset=dataset)
+    manifest.finish_batch(
+        run_id,
+        batch_id,
+        status,
+        rows_read=1,
+        rows_written=1,
+        error_message=error,
+    )
+
+
+def _all_phase_steps_success(manifest: Manifest, run_id: str) -> None:
+    for dataset in (
+        "instruments",
+        "trading_calendar",
+        "daily_bars",
+        "index_bars",
+        "trading_status",
+        "compact",
+        "derive_adj_factors",
+        "derive_industry_index",
+        "audit",
+    ):
+        _add_batch(manifest, run_id, f"{dataset}-b1", dataset, "success")
+
+
+# --- Bug B: retry supersession ----------------------------------------------
+
+
+def test_failed_step_retry_supersedes_old_attempt(cfg, monkeypatch):
+    init_data_layout(cfg)
+    _stub_get_step(monkeypatch)
+    manifest = Manifest(cfg.manifest_path)
+    engine = JobEngine(cfg)
+    run_id = _mk_run(manifest)
+    _add_batch(manifest, run_id, "old-ts", "trading_status", "failed", error="provider down")
+
+    result = engine._run_step("trading_status", date(2024, 6, 28), run_id, {}, retry_of="old-ts")
+
+    assert result["status"] == "success"
+    old = manifest.get_batch(run_id, "old-ts")
+    assert old["status"] == "superseded"
+    assert "superseded by retry batch" in old["error_message"]
+    assert "provider down" in old["error_message"]  # prior error preserved for audit
+    assert manifest.incomplete_batch_count(run_id) == 0
+    batches = manifest.get_batches_for_run(run_id)
+    assert step_succeeded(batches, "trading_status")
+    assert not step_incomplete(batches, "trading_status")
+
+
+def test_stale_step_retry_supersedes_old_attempt(cfg, monkeypatch):
+    init_data_layout(cfg)
+    _stub_get_step(monkeypatch)
+    manifest = Manifest(cfg.manifest_path)
+    engine = JobEngine(cfg)
+    run_id = _mk_run(manifest)
+    _add_batch(manifest, run_id, "old-ts", "trading_status", "stale", error="heartbeat timeout")
+
+    result = engine._run_step("trading_status", date(2024, 6, 28), run_id, {}, retry_of="old-ts")
+
+    assert result["status"] == "success"
+    assert manifest.get_batch(run_id, "old-ts")["status"] == "superseded"
+    assert manifest.incomplete_batch_count(run_id) == 0
+
+
+def test_failed_retry_leaves_attempts_unresolved(cfg, monkeypatch):
+    init_data_layout(cfg)
+    _stub_get_step(monkeypatch, fail={"trading_status"})
+    manifest = Manifest(cfg.manifest_path)
+    engine = JobEngine(cfg)
+    run_id = _mk_run(manifest)
+    _add_batch(manifest, run_id, "old-ts", "trading_status", "failed", error="provider down")
+
+    result = engine._run_step("trading_status", date(2024, 6, 28), run_id, {}, retry_of="old-ts")
+
+    assert result["status"] == "failed"
+    assert manifest.get_batch(run_id, "old-ts")["status"] == "failed"  # not superseded
+    assert manifest.incomplete_batch_count(run_id) == 2
+    batches = manifest.get_batches_for_run(run_id)
+    assert not step_succeeded(batches, "trading_status")
+
+
+def test_running_retry_is_not_resolved(cfg):
+    init_data_layout(cfg)
+    manifest = Manifest(cfg.manifest_path)
+    run_id = _mk_run(manifest)
+    _add_batch(manifest, run_id, "old-ts", "trading_status", "failed")
+    manifest.start_batch(run_id, "new-ts", task_id="trading_status", dataset="trading_status")
+
+    assert manifest.incomplete_batch_count(run_id) == 2
+    batches = manifest.get_batches_for_run(run_id)
+    assert not step_succeeded(batches, "trading_status")
+    assert current_phase_statuses(_PHASES, batches)["phase3_index_and_status"] == "failed"
+
+
+def test_unrelated_failed_batch_is_not_accidentally_resolved(cfg, monkeypatch):
+    init_data_layout(cfg)
+    _stub_get_step(monkeypatch)
+    manifest = Manifest(cfg.manifest_path)
+    engine = JobEngine(cfg)
+    run_id = _mk_run(manifest)
+    # trading_status retried successfully (superseded), audit failed and untouched.
+    _add_batch(manifest, run_id, "old-ts", "trading_status", "failed")
+    _add_batch(manifest, run_id, "audit-fail", "audit", "failed", error="real failure")
+
+    engine._run_step("trading_status", date(2024, 6, 28), run_id, {}, retry_of="old-ts")
+
+    assert manifest.get_batch(run_id, "old-ts")["status"] == "superseded"
+    assert manifest.get_batch(run_id, "audit-fail")["status"] == "failed"
+    assert manifest.incomplete_batch_count(run_id) == 1
+    batches = manifest.get_batches_for_run(run_id)
+    assert step_succeeded(batches, "trading_status")
+    assert not step_succeeded(batches, "audit")
+
+
+# --- Bug A: current phase authority -----------------------------------------
+
+
+def test_historical_failure_does_not_poison_current_success(cfg):
+    init_data_layout(cfg)
+    manifest = Manifest(cfg.manifest_path)
+    engine = JobEngine(cfg)
+    run_id = _mk_run(manifest, historical_failure=True)
+    _all_phase_steps_success(manifest, run_id)
+
+    status = engine._finalize_init_run(
+        run_id,
+        [
+            {"phase": "phase1_reference", "status": "success"},
+            {"phase": "phase2c_daily_bars_backfill", "status": "failed"},
+        ],
+        rows_written=1,
+    )
+
+    assert status == "success"
+    assert engine.manifest.get_run(run_id)["status"] == "success"
+    meta = engine.manifest.get_run_metadata(run_id)
+    # Historical snapshot remains auditable; current view is the authority.
+    assert meta["phase_results"][1]["status"] == "failed"
+    assert meta["current_phase_status"]["phase2c_daily_bars_backfill"] == "success"
+    assert all(v == "success" for v in meta["current_phase_status"].values())
+
+
+def test_current_batch_failure_still_fails_run(cfg):
+    init_data_layout(cfg)
+    manifest = Manifest(cfg.manifest_path)
+    engine = JobEngine(cfg)
+    run_id = _mk_run(manifest)
+    _all_phase_steps_success(manifest, run_id)
+    _add_batch(manifest, run_id, "ts-fail", "trading_status", "failed", error="still broken")
+
+    status = engine._finalize_init_run(run_id, [], rows_written=1)
+
+    assert status == "failed"
+    assert engine.manifest.get_run(run_id)["status"] == "failed"
+    meta = engine.manifest.get_run_metadata(run_id)
+    assert meta["current_phase_status"]["phase3_index_and_status"] == "failed"
+
+
+def test_running_retry_blocks_final_success(cfg):
+    init_data_layout(cfg)
+    manifest = Manifest(cfg.manifest_path)
+    engine = JobEngine(cfg)
+    run_id = _mk_run(manifest)
+    _all_phase_steps_success(manifest, run_id)
+    manifest.start_batch(run_id, "ts-running", task_id="trading_status", dataset="trading_status")
+
+    status = engine._finalize_init_run(run_id, [], rows_written=1)
+
+    assert status == "failed"
+
+
+# --- resume flow (Bug A + B together) ---------------------------------------
+
+
+def test_resume_reaches_success_after_retry_supersedes_failed_phase(cfg, monkeypatch):
+    """Original phase2c failed; retry succeeds; FINAL_RUN_STATUS=success."""
+    init_data_layout(cfg)
+    _stub_get_step(monkeypatch)
+    manifest = Manifest(cfg.manifest_path)
+    engine = JobEngine(cfg)
+    run_id = _mk_run(manifest, historical_failure=True)
+    # phase1/phase3 batches already success; phase2c batch failed (to be retried).
+    for ds in ("instruments", "trading_calendar", "index_bars", "trading_status"):
+        _add_batch(manifest, run_id, f"{ds}-b1", ds, "success")
+    _add_batch(manifest, run_id, "daily-old", "daily_bars", "failed", error="TDX no bars")
+
+    result = engine.resume_init(date(2024, 6, 28), run_id=run_id)
+
+    assert result["status"] == "success"
+    assert manifest.get_run(run_id)["status"] == "success"
+    assert manifest.get_batch(run_id, "daily-old")["status"] == "superseded"
+    assert manifest.incomplete_batch_count(run_id) == 0
+    meta = manifest.get_run_metadata(run_id)
+    assert meta["current_phase_status"]["phase2c_daily_bars_backfill"] == "success"
+    historical = [p for p in meta["phase_results"] if p["phase"] == "phase2c_daily_bars_backfill"]
+    assert historical and historical[0]["status"] == "failed"  # auditable
+
+
+def test_resume_stays_failed_when_retry_also_fails(cfg, monkeypatch):
+    init_data_layout(cfg)
+    _stub_get_step(monkeypatch, fail={"daily_bars"})
+    manifest = Manifest(cfg.manifest_path)
+    engine = JobEngine(cfg)
+    run_id = _mk_run(manifest)
+    for ds in ("instruments", "trading_calendar", "index_bars", "trading_status"):
+        _add_batch(manifest, run_id, f"{ds}-b1", ds, "success")
+    _add_batch(manifest, run_id, "daily-old", "daily_bars", "failed", error="TDX no bars")
+
+    result = engine.resume_init(date(2024, 6, 28), run_id=run_id)
+
+    assert result["status"] == "failed"
+    assert manifest.get_run(run_id)["status"] == "failed"
+
+
+# --- finalize gate / compact gate -------------------------------------------
+
+
+def test_finalize_allowed_after_legitimate_supersession(cfg):
+    init_data_layout(cfg)
+    manifest = Manifest(cfg.manifest_path)
+    run_id = _mk_run(manifest)
+    for ds in ("instruments", "trading_calendar", "daily_bars", "index_bars", "trading_status"):
+        _add_batch(manifest, run_id, f"{ds}-b1", ds, "success")
+    # trading_status old attempt superseded by a successful retry.
+    _add_batch(manifest, run_id, "old-ts", "trading_status", "failed")
+    _add_batch(manifest, run_id, "new-ts", "trading_status", "success")
+    manifest.supersede_batch(run_id, "old-ts", superseded_by="new-ts", prior_error="x")
+
+    batches = manifest.get_batches_for_run(run_id)
+    assert init_run_complete([p for p in _PHASES if p != "phase4_finalize"], batches)
+    assert needs_finalize(_PHASES, batches)
+    assert manifest.incomplete_batch_count(run_id) == 0
+
+
+def test_compact_allowed_after_supersession_but_blocked_by_unresolved(cfg):
+    init_data_layout(cfg)
+    manifest = Manifest(cfg.manifest_path)
+    run_id = _mk_run(manifest)
+    _add_batch(manifest, run_id, "old-ts", "trading_status", "failed")
+    _add_batch(manifest, run_id, "new-ts", "trading_status", "success")
+    _add_batch(manifest, run_id, "audit-fail", "audit", "failed")
+    manifest.supersede_batch(run_id, "old-ts", superseded_by="new-ts", prior_error="x")
+
+    allowed_ts, _ = compact_allowed(manifest, run_id, "trading_status")
+    allowed_audit, _ = compact_allowed(manifest, run_id, "audit")
+    assert allowed_ts is True  # superseded attempt no longer blocks compact
+    assert allowed_audit is False  # genuinely unresolved batch still blocks
+
+
+# --- real run read-only replay ----------------------------------------------
+
+REAL_MANIFEST = "/Users/luke808/AI/asl-shared/meta/manifest.db"
+REAL_RUN_ID = "0280a169-e73d-4d0c-a358-d0637ed8ca99"
+
+
+def _would_be_superseded(batches: list[dict]) -> set[str]:
+    """Read-only estimate: failed/stale batch with a LATER same-dataset success."""
+    resolved: set[str] = set()
+    by_dataset: dict[str, list[dict]] = {}
+    for b in batches:
+        by_dataset.setdefault(b["dataset"], []).append(b)
+    for rows in by_dataset.values():
+        successes = [r for r in rows if r["status"] == "success" and r["started_at"]]
+        if not successes:
+            continue
+        earliest = min(r["started_at"] for r in successes)
+        for r in rows:
+            if (
+                r["status"] in ("failed", "stale")
+                and r["started_at"]
+                and r["started_at"] < earliest
+            ):
+                resolved.add(r["batch_id"])
+    return resolved
+
+
+def test_real_run_readonly_ledger_replay(tmp_path):
+    """Read-only replay of run 0280a169 with the patched ledger semantics."""
+    if not __import__("os").path.exists(REAL_MANIFEST):
+        pytest.skip("real shared manifest not present")
+    conn = sqlite3.connect(f"file:{REAL_MANIFEST}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        run = conn.execute(
+            "SELECT * FROM ingestion_runs WHERE run_id = ?", (REAL_RUN_ID,)
+        ).fetchone()
+        assert run is not None
+        rows = conn.execute(
+            "SELECT * FROM ingestion_batches WHERE run_id = ?", (REAL_RUN_ID,)
+        ).fetchall()
+    finally:
+        conn.close()
+
+    batches = [dict(r) for r in rows]
+    superseded = _would_be_superseded(batches)
+    old_incomplete = sum(1 for b in batches if b["status"] not in ("success", "superseded"))
+    true_unresolved = old_incomplete - len(superseded)
+    assert old_incomplete == 1, batches
+    assert true_unresolved == 0, batches
+
+    expected_steps = [
+        "instruments",
+        "trading_calendar",
+        "corporate_actions",
+        "daily_bars",
+        "index_bars",
+        "trading_status",
+        "compact",
+        "derive_adj_factors",
+        "derive_industry_index",
+        "audit",
+    ]
+    current: dict[str, str] = {}
+    for step in expected_steps:
+        step_rows = [b for b in batches if b["dataset"] == step]
+        unresolved = [
+            b
+            for b in step_rows
+            if b["status"] not in ("success", "superseded") and b["batch_id"] not in superseded
+        ]
+        current[step] = "CURRENT_FAILED" if unresolved else "CURRENT_SUCCESS"
+    assert current["daily_bars"] == "CURRENT_SUCCESS"
+    assert current["trading_status"] == "CURRENT_SUCCESS"
+    assert current["compact"] == "CURRENT_SUCCESS"
+    assert current["derive_adj_factors"] == "CURRENT_SUCCESS"
+    assert all(v == "CURRENT_SUCCESS" for v in current.values())

--- a/tests/unit/test_resume_ledger.py
+++ b/tests/unit/test_resume_ledger.py
@@ -362,7 +362,12 @@ def _would_be_superseded(batches: list[dict]) -> set[str]:
 
 
 def test_real_run_readonly_ledger_replay(tmp_path):
-    """Read-only replay of run 0280a169 with the patched ledger semantics."""
+    """Read-only replay of run 0280a169 with the patched ledger semantics.
+
+    The real run has already been ledger-reconciled (old orphan batch is
+    explicitly ``superseded``, run status success), so the replay must find
+    zero unresolved batches and every step currently successful.
+    """
     if not __import__("os").path.exists(REAL_MANIFEST):
         pytest.skip("real shared manifest not present")
     conn = sqlite3.connect(f"file:{REAL_MANIFEST}?mode=ro", uri=True)
@@ -382,8 +387,10 @@ def test_real_run_readonly_ledger_replay(tmp_path):
     superseded = _would_be_superseded(batches)
     old_incomplete = sum(1 for b in batches if b["status"] not in ("success", "superseded"))
     true_unresolved = old_incomplete - len(superseded)
-    assert old_incomplete == 1, batches
+    assert any(b["status"] == "superseded" for b in batches), batches
+    assert old_incomplete == 0, batches
     assert true_unresolved == 0, batches
+    assert run["status"] == "success"
 
     expected_steps = [
         "instruments",

--- a/tests/unit/test_trading_status_history.py
+++ b/tests/unit/test_trading_status_history.py
@@ -3,7 +3,10 @@ from datetime import date
 import polars as pl
 
 from ashare_lake.config import Config
-from ashare_lake.derive.trading_status_history import derive_suspension_history
+from ashare_lake.derive.trading_status_history import (
+    derive_suspension_history,
+    status_row_precedence_class,
+)
 
 
 def _write(root, dataset, partition_col, val, df):
@@ -167,3 +170,320 @@ def test_derive_suspension_respects_end_window(tmp_path):
         date(2015, 12, 31)
     ]
     assert not (root / "curated" / "trading_status" / "trade_date=2016-01").exists()
+
+
+def _ts_row(symbol: str, trade_date: date, *, source: str, fetched_at: str) -> dict:
+    return {
+        "symbol": symbol,
+        "trade_date": trade_date,
+        "is_trading": True,
+        "status": "normal",
+        "source": source,
+        "data_version": "v1",
+        "fetched_at": fetched_at,
+    }
+
+
+def _write_existing_status(root, trade_date: date, rows: list[dict]) -> None:
+    _write(
+        root,
+        "trading_status",
+        "trade_date",
+        trade_date.strftime("%Y-%m"),
+        pl.DataFrame(rows),
+    )
+
+
+def _read_status(root) -> pl.DataFrame:
+    files = sorted((root / "curated" / "trading_status").rglob("*.parquet"))
+    return pl.concat([pl.read_parquet(f) for f in files], how="diagonal_relaxed")
+
+
+def _mini_lake(root) -> None:
+    cfg = Config(data_root=root)
+    days = [date(2024, 6, 26), date(2024, 6, 27), date(2024, 6, 28)]
+    for d in days:
+        _write(
+            root,
+            "trading_calendar",
+            "trade_date",
+            d.isoformat(),
+            pl.DataFrame(
+                {
+                    "trade_date": [d],
+                    "is_trading": [True],
+                    "source": ["seed"],
+                    "data_version": ["v1"],
+                    "fetched_at": ["2024-06-28T00:00:00+00:00"],
+                }
+            ),
+        )
+    for d in days:
+        rows = [
+            {
+                "symbol": "600519.SH",
+                "trade_date": d,
+                "open": 1.0,
+                "high": 1.0,
+                "low": 1.0,
+                "close": 1.0,
+                "volume": 1,
+                "amount": 1.0,
+                "source": "tdx_protocol",
+                "data_version": "v1",
+                "fetched_at": "2024-06-28T00:00:00+00:00",
+            }
+        ]
+        if d != date(2024, 6, 27):
+            rows.append(
+                {
+                    "symbol": "000001.SZ",
+                    "trade_date": d,
+                    "open": 1.0,
+                    "high": 1.0,
+                    "low": 1.0,
+                    "close": 1.0,
+                    "volume": 1,
+                    "amount": 1.0,
+                    "source": "tdx_protocol",
+                    "data_version": "v1",
+                    "fetched_at": "2024-06-28T00:00:00+00:00",
+                }
+            )
+        _write(root, "daily_bars", "trade_date", d.isoformat(), pl.DataFrame(rows))
+    (root / "curated" / "instruments").mkdir(parents=True, exist_ok=True)
+    pl.DataFrame(
+        {
+            "symbol": ["600519.SH", "000001.SZ"],
+            "list_date": [date(2000, 1, 1), date(2000, 1, 1)],
+            "delist_date": [None, None],
+        }
+    ).write_parquet(root / "curated" / "instruments" / "part-merged.parquet")
+    return cfg
+
+
+def _derive_with_existing(tmp_path, existing: list[dict]) -> pl.DataFrame:
+    root = tmp_path / "data"
+    cfg = _mini_lake(root)
+    _write_existing_status(root, date(2024, 6, 27), existing)
+    derive_suspension_history(cfg)
+    return _read_status(root)
+
+
+def _suspended_row(status: pl.DataFrame) -> pl.DataFrame:
+    return status.filter(
+        (pl.col("symbol") == "000001.SZ") & (pl.col("trade_date") == date(2024, 6, 27))
+    )
+
+
+def test_derived_wins_over_legacy_tdx_non_pit_row(tmp_path):
+    """T1: legacy tdx_protocol normal row fetched on a later session loses."""
+    status = _derive_with_existing(
+        tmp_path,
+        [
+            _ts_row(
+                "000001.SZ",
+                date(2024, 6, 27),
+                source="tdx_protocol",
+                fetched_at="2024-06-28T00:00:00+00:00",
+            )
+        ],
+    )
+    row = _suspended_row(status)
+    assert row.height == 1
+    assert row["source"][0] == "derived_bar_gap"
+    assert row["status"][0] == "suspended"
+    assert row["is_trading"][0] is False
+
+
+def test_derived_wins_over_eastmoney_non_pit_row(tmp_path):
+    """T2: eastmoney normal row fetched on a later session loses."""
+    status = _derive_with_existing(
+        tmp_path,
+        [
+            _ts_row(
+                "000001.SZ",
+                date(2024, 6, 27),
+                source="eastmoney",
+                fetched_at="2024-06-28T00:00:00+00:00",
+            )
+        ],
+    )
+    row = _suspended_row(status)
+    assert row.height == 1
+    assert row["source"][0] == "derived_bar_gap"
+
+
+def test_same_session_eastmoney_row_keeps_precedence(tmp_path):
+    """T3: same-session eastmoney normal row must not be reinterpreted."""
+    status = _derive_with_existing(
+        tmp_path,
+        [
+            _ts_row(
+                "000001.SZ",
+                date(2024, 6, 27),
+                source="eastmoney",
+                fetched_at="2024-06-27T02:00:00+00:00",
+            )
+        ],  # Shanghai 06-27
+    )
+    row = _suspended_row(status)
+    assert row.height == 1
+    assert row["source"][0] == "eastmoney"
+    assert row["status"][0] == "normal"
+
+
+def test_same_session_eastmoney_suspended_row_kept(tmp_path):
+    """T4: same-session suspended row remains authoritative."""
+    status = _derive_with_existing(
+        tmp_path,
+        [
+            {
+                "symbol": "000001.SZ",
+                "trade_date": date(2024, 6, 27),
+                "is_trading": False,
+                "status": "suspended",
+                "source": "eastmoney",
+                "data_version": "v1",
+                "fetched_at": "2024-06-27T02:00:00+00:00",
+            }
+        ],
+    )
+    row = _suspended_row(status)
+    assert row.height == 1
+    assert row["source"][0] == "eastmoney"
+    assert row["status"][0] == "suspended"
+
+
+def test_baostock_row_keeps_precedence(tmp_path):
+    """T5: baostock ST rows are never reclassified."""
+    status = _derive_with_existing(
+        tmp_path,
+        [
+            {
+                "symbol": "000001.SZ",
+                "trade_date": date(2024, 6, 27),
+                "is_trading": True,
+                "status": "ST",
+                "source": "baostock",
+                "data_version": "v1",
+                "fetched_at": "2024-06-28T00:00:00+00:00",
+            }
+        ],
+    )
+    row = _suspended_row(status)
+    assert row.height == 1
+    assert row["source"][0] == "baostock"
+
+
+def test_unknown_source_keeps_precedence(tmp_path):
+    """T6: unknown sources are preserved, never discarded as NON-PIT."""
+    status = _derive_with_existing(
+        tmp_path,
+        [
+            _ts_row(
+                "000001.SZ",
+                date(2024, 6, 27),
+                source="mystery_provider",
+                fetched_at="2024-06-28T00:00:00+00:00",
+            )
+        ],
+    )
+    row = _suspended_row(status)
+    assert row.height == 1
+    assert row["source"][0] == "mystery_provider"
+
+
+def test_no_collision_derive_unchanged(tmp_path):
+    """T7: without a collision the derive behaves as before."""
+    root = tmp_path / "data"
+    cfg = _mini_lake(root)
+    result = derive_suspension_history(cfg)
+    status = _read_status(root)
+    assert result == 1
+    assert status.height == 1
+    assert status["source"][0] == "derived_bar_gap"
+
+
+def test_precedence_class_pure_contract():
+    """Direct unit tests for the classifier (T1/T3/T5/T6/T8)."""
+    tdx_later = {
+        "source": "tdx_protocol",
+        "trade_date": date(2026, 8, 4),
+        "fetched_at": "2026-08-10T01:32:34+08:00",
+    }
+    assert status_row_precedence_class(tdx_later) == "NON_PIT_DAILY_SNAPSHOT"
+
+    em_same = {
+        "source": "eastmoney",
+        "trade_date": date(2026, 8, 4),
+        "fetched_at": "2026-08-04T02:00:00+00:00",  # Shanghai 08-04
+    }
+    assert status_row_precedence_class(em_same) == "TRUSTED_SAME_SESSION_DAILY"
+
+    assert (
+        status_row_precedence_class(
+            {"source": "baostock", "trade_date": date(2026, 8, 4), "fetched_at": None}
+        )
+        == "BAOSTOCK"
+    )
+    assert (
+        status_row_precedence_class(
+            {"source": "weird", "trade_date": date(2026, 8, 4), "fetched_at": None}
+        )
+        == "OTHER"
+    )
+    assert (
+        status_row_precedence_class(
+            {"source": "derived_bar_gap", "trade_date": date(2026, 8, 4), "fetched_at": None}
+        )
+        == "DERIVED_BAR_GAP"
+    )
+
+    # T8: UTC timestamp whose Shanghai date equals trade_date.
+    utc_evening = {
+        "source": "eastmoney",
+        "trade_date": date(2026, 8, 4),
+        "fetched_at": "2026-08-03T20:00:00+00:00",  # Shanghai 08-04 04:00
+    }
+    assert status_row_precedence_class(utc_evening) == "TRUSTED_SAME_SESSION_DAILY"
+
+    # Missing fetched_at cannot prove same-session.
+    assert (
+        status_row_precedence_class(
+            {"source": "eastmoney", "trade_date": date(2026, 8, 4), "fetched_at": None}
+        )
+        == "NON_PIT_DAILY_SNAPSHOT"
+    )
+
+
+def test_daily_step_stamps_eastmoney_provenance(tmp_path, monkeypatch):
+    """The official daily trading_status step must stamp EastMoney provenance."""
+    from ashare_lake.steps.reference import step_trading_status
+
+    root = tmp_path / "data"
+    cfg = Config(data_root=root)
+    fetched = pl.DataFrame(
+        [
+            {
+                "symbol": "600000.SH",
+                "trade_date": date(2026, 8, 7),
+                "is_trading": True,
+                "status": "normal",
+            }
+        ]
+    )
+
+    def fake_fetch(config, dataset, trade_date, fetch_fn, *, allow_empty=False):
+        return fetched, []
+
+    monkeypatch.setattr("ashare_lake.steps.reference.fetch_incremental_daily", fake_fetch)
+    monkeypatch.setattr("ashare_lake.steps.reference.load_symbols", lambda config: ["600000.SH"])
+
+    step_trading_status(cfg, date(2026, 8, 7), "run-1", {})
+
+    staged = sorted((root / "staging" / "trading_status").rglob("*.parquet"))
+    assert staged
+    written = pl.read_parquet(staged[0])
+    assert written["source"].to_list() == ["eastmoney"]
+    assert written["status"].to_list() == ["normal"]

--- a/tests/unit/test_trading_status_st_backfill.py
+++ b/tests/unit/test_trading_status_st_backfill.py
@@ -7,6 +7,7 @@ fail-loud finding on dropped symbols.
 
 from __future__ import annotations
 
+import json
 from datetime import date
 
 import polars as pl
@@ -16,6 +17,8 @@ from ashare_lake.steps import reference
 from ashare_lake.steps.reference import (
     _backfill_trading_status_st,
     _st_backfilled_symbols,
+    _st_completed_symbols,
+    _st_scope_checkpoint_path,
 )
 
 
@@ -32,8 +35,10 @@ def _st_row(symbol: str, d: date) -> dict:
 def _patch(monkeypatch, *, returns):
     """Stub the network fetch and the curated write; return a captured-writes list."""
     written: list[pl.DataFrame] = []
+    calls: list[tuple] = []
 
     def fake_fetch(symbols, start, end, **kwargs):
+        calls.append((list(symbols), start, end))
         df, failed = returns
         return df, failed
 
@@ -43,14 +48,14 @@ def _patch(monkeypatch, *, returns):
 
     monkeypatch.setattr("ashare_lake.adapters.baostock.st_history.fetch_st_history", fake_fetch)
     monkeypatch.setattr(reference, "write_fetched", fake_write)
-    return written
+    return written, calls
 
 
 def test_writes_st_rows_and_marks_all_swept_symbols(tmp_path, monkeypatch):
     cfg = Config(data_root=tmp_path / "data")
     _write_instruments(cfg, ["600000.SH", "600001.SH"])  # both all_a, no ST for 600001
     df = pl.DataFrame([_st_row("600000.SH", date(2020, 5, 6))])
-    written = _patch(monkeypatch, returns=(df, []))
+    written, _calls = _patch(monkeypatch, returns=(df, []))
 
     result = _backfill_trading_status_st(cfg, date(2026, 7, 1), "run1")
 
@@ -93,3 +98,258 @@ def test_failed_symbols_are_not_marked_and_surface_a_finding(tmp_path, monkeypat
     finding = result["context_updates"]["audit_findings"][0]
     assert finding["code"] == "baostock_st_backfill_incomplete"
     assert finding["severity"] == "warning"
+
+
+def _scope_cfg(tmp_path, symbols, **attrs):
+    cfg = Config(data_root=tmp_path / "data")
+    _write_instruments(cfg, symbols)
+    for key, value in attrs.items():
+        setattr(cfg, key, value)
+    return cfg
+
+
+def test_start_reaches_fetch_st_history(tmp_path, monkeypatch):
+    cfg = _scope_cfg(tmp_path, ["600000.SH"], _backfill_start=date(2026, 3, 30))
+    df = pl.DataFrame([_st_row("600000.SH", date(2026, 5, 6))])
+    _written, calls = _patch(monkeypatch, returns=(df, []))
+
+    _backfill_trading_status_st(cfg, date(2026, 8, 7), "run1")
+
+    assert calls[0][1] == date(2026, 3, 30)
+
+
+def test_end_reaches_fetch_st_history(tmp_path, monkeypatch):
+    cfg = _scope_cfg(
+        tmp_path,
+        ["600000.SH"],
+        _backfill_start=date(2026, 3, 30),
+        _backfill_end=date(2026, 8, 7),
+    )
+    df = pl.DataFrame([_st_row("600000.SH", date(2026, 5, 6))])
+    _written, calls = _patch(monkeypatch, returns=(df, []))
+
+    _backfill_trading_status_st(cfg, date(2026, 8, 10), "run1")
+
+    assert calls[0][2] == date(2026, 8, 7)  # NOT date.today() / trade_date
+
+
+def test_inverted_window_fails_closed(tmp_path, monkeypatch):
+    cfg = _scope_cfg(
+        tmp_path,
+        ["600000.SH"],
+        _backfill_start=date(2026, 8, 7),
+        _backfill_end=date(2026, 3, 30),
+    )
+    _patch(monkeypatch, returns=(pl.DataFrame(), []))
+
+    try:
+        _backfill_trading_status_st(cfg, date(2026, 8, 10), "run1")
+        raise AssertionError("expected ValueError")
+    except ValueError as exc:
+        assert "inverted" in str(exc)
+
+
+def test_explicit_symbol_scope_queries_only_those_symbols(tmp_path, monkeypatch):
+    cfg = _scope_cfg(
+        tmp_path,
+        ["600000.SH", "600001.SH", "000001.SZ"],
+        _backfill_symbols=["600000.SH", "000001"],
+    )
+    df = pl.DataFrame([_st_row("600000.SH", date(2026, 5, 6))])
+    _written, calls = _patch(monkeypatch, returns=(df, []))
+
+    _backfill_trading_status_st(cfg, date(2026, 8, 7), "run1")
+
+    queried = {s for call in calls for s in call[0]}
+    assert queried == {"600000.SH", "000001.SZ"}  # 600001.SH never queried
+
+
+def test_malformed_explicit_symbol_fails_closed(tmp_path, monkeypatch):
+    cfg = _scope_cfg(tmp_path, ["600000.SH"], _backfill_symbols=["NOT_A_SYMBOL"])
+    _patch(monkeypatch, returns=(pl.DataFrame(), []))
+
+    try:
+        _backfill_trading_status_st(cfg, date(2026, 8, 7), "run1")
+        raise AssertionError("expected ValueError")
+    except ValueError as exc:
+        assert "malformed symbol" in str(exc)
+
+
+def test_unknown_explicit_symbol_fails_closed(tmp_path, monkeypatch):
+    cfg = _scope_cfg(tmp_path, ["600000.SH"], _backfill_symbols=["999999.SH"])
+    _patch(monkeypatch, returns=(pl.DataFrame(), []))
+
+    try:
+        _backfill_trading_status_st(cfg, date(2026, 8, 7), "run1")
+        raise AssertionError("expected ValueError")
+    except ValueError as exc:
+        assert "unknown instrument" in str(exc)
+
+
+def test_default_path_remains_all_a_2016(tmp_path, monkeypatch):
+    cfg = _scope_cfg(tmp_path, ["600000.SH", "600001.SH"])
+    df = pl.DataFrame([_st_row("600000.SH", date(2020, 5, 6))])
+    _written, calls = _patch(monkeypatch, returns=(df, []))
+
+    result = _backfill_trading_status_st(cfg, date(2026, 7, 1), "run1")
+
+    assert result["scope_id"] is None
+    assert calls[0][1] == date(2016, 1, 1)  # BACKFILL_START
+    assert calls[0][2] == date(2026, 7, 1)  # trade_date
+
+
+def test_same_scope_resume_skips_completed(tmp_path, monkeypatch):
+    cfg = _scope_cfg(
+        tmp_path,
+        ["600000.SH", "000001.SZ"],
+        _backfill_start=date(2026, 3, 30),
+        _backfill_end=date(2026, 8, 7),
+        _backfill_symbols=["600000.SH", "000001.SZ"],
+    )
+    df = pl.DataFrame([_st_row("600000.SH", date(2026, 5, 6))])
+    _written, calls = _patch(monkeypatch, returns=(df, []))
+    first = _backfill_trading_status_st(cfg, date(2026, 8, 7), "run1")
+    assert first["scope_id"] is not None
+
+    second = _backfill_trading_status_st(cfg, date(2026, 8, 7), "run2")
+
+    assert len(calls) == 1  # first run only
+    assert "already ST-backfilled" in second["note"]
+
+
+def test_zero_st_successful_sweep_counts_completed(tmp_path, monkeypatch):
+    cfg = _scope_cfg(
+        tmp_path,
+        ["600000.SH"],
+        _backfill_start=date(2026, 3, 30),
+        _backfill_end=date(2026, 8, 7),
+        _backfill_symbols=["600000.SH"],
+    )
+    _written, calls = _patch(monkeypatch, returns=(pl.DataFrame(), []))  # zero ST rows
+
+    result = _backfill_trading_status_st(cfg, date(2026, 8, 7), "run1")
+
+    assert result["rows_written"] == 0
+    assert _st_completed_symbols(cfg, result["scope_id"]) == {"600000.SH"}
+
+
+def test_failed_symbol_remains_todo(tmp_path, monkeypatch):
+    cfg = _scope_cfg(
+        tmp_path,
+        ["600000.SH", "000001.SZ"],
+        _backfill_start=date(2026, 3, 30),
+        _backfill_end=date(2026, 8, 7),
+        _backfill_symbols=["600000.SH", "000001.SZ"],
+    )
+    _written, calls = _patch(monkeypatch, returns=(pl.DataFrame(), ["000001.SZ"]))
+    first = _backfill_trading_status_st(cfg, date(2026, 8, 7), "run1")
+    assert first["failed_symbols"] == 1
+
+    second = _backfill_trading_status_st(cfg, date(2026, 8, 7), "run2")
+    assert "already ST-backfilled" not in second.get("note", "")
+    # Only the failed symbol remains todo (600000.SH was completed).
+    assert set(calls[1][0]) == {"000001.SZ"}
+    assert second["failed_symbols"] == 1  # mocked fetch fails 000001 again
+
+
+def test_shallow_checkpoint_does_not_suppress_deeper_run(tmp_path, monkeypatch):
+    cfg = _scope_cfg(
+        tmp_path,
+        ["600000.SH", "000001.SZ"],
+        _backfill_start=date(2026, 3, 30),
+        _backfill_end=date(2026, 8, 7),
+        _backfill_symbols=["600000.SH", "000001.SZ"],
+    )
+    _written, calls = _patch(monkeypatch, returns=(pl.DataFrame(), []))
+    _backfill_trading_status_st(cfg, date(2026, 8, 7), "run1")
+    assert len(calls) == 1
+
+    # Deeper/default scope: the shallow completion must NOT suppress A/B.
+    cfg._backfill_start = None
+    cfg._backfill_end = None
+    cfg._backfill_symbols = None
+    deep = _backfill_trading_status_st(cfg, date(2026, 8, 7), "run2")
+    assert len(calls) == 2  # second fetch happened
+    assert deep["scope_id"] is None  # legacy default scope
+    assert "already ST-backfilled" not in deep.get("note", "")
+
+
+def test_different_scope_does_not_poison_another_scope(tmp_path, monkeypatch):
+    cfg = _scope_cfg(
+        tmp_path,
+        ["600000.SH", "000001.SZ"],
+        _backfill_start=date(2026, 3, 30),
+        _backfill_end=date(2026, 8, 7),
+        _backfill_symbols=["600000.SH"],
+    )
+    _written, calls = _patch(monkeypatch, returns=(pl.DataFrame(), []))
+    first = _backfill_trading_status_st(cfg, date(2026, 8, 7), "run1")
+
+    cfg._backfill_symbols = ["000001.SZ"]  # same dates, different symbols
+    second = _backfill_trading_status_st(cfg, date(2026, 8, 7), "run2")
+
+    assert first["scope_id"] != second["scope_id"]
+    assert len(calls) == 2  # 000001.SZ was NOT suppressed by scope 1
+
+
+def test_legacy_checkpoint_only_counts_for_legacy_scope(tmp_path, monkeypatch):
+    cfg = _scope_cfg(tmp_path, ["600000.SH", "000001.SZ"])
+    # Legacy file claims 600000.SH done for the default scope.
+    path = reference._st_backfill_state_path(cfg)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"completed": ["600000.SH"]}))
+
+    df = pl.DataFrame([_st_row("000001.SZ", date(2020, 5, 6))])
+    _written, calls = _patch(monkeypatch, returns=(df, []))
+    legacy = _backfill_trading_status_st(cfg, date(2026, 7, 1), "run1")
+    assert len(calls) == 1  # only 000001.SZ todo (600000.SH skipped by legacy)
+    assert legacy["scope_id"] is None
+
+    # Custom scope: legacy completion must NOT be reused.
+    cfg._backfill_start = date(2026, 3, 30)
+    cfg._backfill_end = date(2026, 8, 7)
+    cfg._backfill_symbols = ["600000.SH"]
+    _backfill_trading_status_st(cfg, date(2026, 8, 7), "run2")
+    assert len(calls) == 2  # 600000.SH queried again for the custom scope
+
+
+def test_st_output_semantics_unchanged(tmp_path, monkeypatch):
+    cfg = _scope_cfg(
+        tmp_path,
+        ["600000.SH"],
+        _backfill_start=date(2026, 3, 30),
+        _backfill_end=date(2026, 8, 7),
+        _backfill_symbols=["600000.SH"],
+    )
+    df = pl.DataFrame([_st_row("600000.SH", date(2026, 5, 6))])
+    written, _calls = _patch(monkeypatch, returns=(df, []))
+
+    _backfill_trading_status_st(cfg, date(2026, 8, 7), "run1")
+
+    row = written[0]
+    # Fetch-level ST semantics are passed through unchanged (write_fetched
+    # stamps source=baostock in production).
+    assert row["status"].to_list() == ["st"]
+    assert row["is_trading"].to_list() == [True]
+    assert row["symbol"].to_list() == ["600000.SH"]
+
+
+def test_scope_checkpoint_file_is_per_scope(tmp_path, monkeypatch):
+    cfg = _scope_cfg(
+        tmp_path,
+        ["600000.SH"],
+        _backfill_start=date(2026, 3, 30),
+        _backfill_end=date(2026, 8, 7),
+        _backfill_symbols=["600000.SH"],
+    )
+    _patch(monkeypatch, returns=(pl.DataFrame(), []))
+    result = _backfill_trading_status_st(cfg, date(2026, 8, 7), "run1")
+
+    path = _st_scope_checkpoint_path(cfg, result["scope_id"])
+    assert path.exists()
+    payload = json.loads(path.read_text())
+    assert payload["scope_version"] == 1
+    assert payload["start"] == "2026-03-30"
+    assert payload["end"] == "2026-08-07"
+    assert payload["symbol_hash"]
+    assert payload["completed"] == ["600000.SH"]

--- a/tests/unit/test_trading_status_st_backfill.py
+++ b/tests/unit/test_trading_status_st_backfill.py
@@ -353,3 +353,189 @@ def test_scope_checkpoint_file_is_per_scope(tmp_path, monkeypatch):
     assert payload["end"] == "2026-08-07"
     assert payload["symbol_hash"]
     assert payload["completed"] == ["600000.SH"]
+
+
+def _orchestrated(cfg, monkeypatch, returns):
+    """Engine-level backfill + CLI finish (compact + finish_run), fetch stubbed."""
+    from ashare_lake.cli.main import _finish_backfill_run
+    from ashare_lake.orchestrator.engine import JobEngine
+
+    calls: list[tuple] = []
+
+    def fake_fetch(symbols, start, end, **kwargs):
+        calls.append((list(symbols), start, end))
+        df, failed = returns
+        return df, failed
+
+    monkeypatch.setattr("ashare_lake.adapters.baostock.st_history.fetch_st_history", fake_fetch)
+    engine = JobEngine(cfg)
+    result = engine.run_job(
+        "backfill",
+        steps=["trading_status"],
+        backfill=True,
+        finalize_run=False,
+    )
+    out = _finish_backfill_run(engine, result)
+    return out, calls, engine
+
+
+def _orchestrated_cfg(tmp_path, symbols, **attrs):
+    cfg = _scope_cfg(tmp_path, symbols, **attrs)
+    from ashare_lake.storage.layout import init_data_layout
+
+    init_data_layout(cfg)
+    return cfg
+
+
+def test_orchestration_all_success(tmp_path, monkeypatch):
+    cfg = _orchestrated_cfg(
+        tmp_path,
+        ["600000.SH"],
+        _backfill_start=date(2026, 3, 30),
+        _backfill_end=date(2026, 8, 7),
+        _backfill_symbols=["600000.SH"],
+    )
+    df = pl.DataFrame([_st_row("600000.SH", date(2026, 5, 6))])
+
+    out, _calls, engine = _orchestrated(cfg, monkeypatch, returns=(df, []))
+
+    assert out["status"] == "success"
+    assert out["compact"]["status"] == "success"
+    assert engine.manifest.get_run(out["run_id"])["status"] == "success"
+
+
+def test_orchestration_partial_failure_warns_and_compacts(tmp_path, monkeypatch):
+    cfg = _orchestrated_cfg(
+        tmp_path,
+        ["600000.SH", "000001.SZ"],
+        _backfill_start=date(2026, 3, 30),
+        _backfill_end=date(2026, 8, 7),
+        _backfill_symbols=["600000.SH", "000001.SZ"],
+    )
+    df = pl.DataFrame([_st_row("600000.SH", date(2026, 5, 6))])
+
+    out, _calls, engine = _orchestrated(cfg, monkeypatch, returns=(df, ["000001.SZ"]))
+
+    assert out["status"] == "warning"
+    assert out["results"][0]["status"] == "warning"
+    assert out["results"][0]["failed_symbols"] == 1
+    assert out["compact"]["status"] == "success"  # partial success still compacted
+    assert engine.manifest.get_run(out["run_id"])["status"] == "warning"
+    # Successful row reached curated via compact.
+    files = list((cfg.curated_root / "trading_status").rglob("*.parquet"))
+    assert files
+    curated = pl.read_parquet(files[0])
+    assert curated["symbol"].to_list() == ["600000.SH"]
+
+
+def test_orchestration_partial_failure_resume(tmp_path, monkeypatch):
+    cfg = _orchestrated_cfg(
+        tmp_path,
+        ["600000.SH", "000001.SZ"],
+        _backfill_start=date(2026, 3, 30),
+        _backfill_end=date(2026, 8, 7),
+        _backfill_symbols=["600000.SH", "000001.SZ"],
+    )
+    df = pl.DataFrame([_st_row("600000.SH", date(2026, 5, 6))])
+
+    first, calls, engine = _orchestrated(cfg, monkeypatch, returns=(df, ["000001.SZ"]))
+    assert first["status"] == "warning"
+
+    second, calls2, engine2 = _orchestrated(cfg, monkeypatch, returns=(df, []))
+    assert second["status"] == "success"
+    assert set(calls2[-1][0]) == {"000001.SZ"}  # only the failed symbol re-queried
+    assert engine2.manifest.get_run(second["run_id"])["status"] == "success"
+
+
+def test_orchestration_zero_st_success_no_warning(tmp_path, monkeypatch):
+    cfg = _orchestrated_cfg(
+        tmp_path,
+        ["600000.SH"],
+        _backfill_start=date(2026, 3, 30),
+        _backfill_end=date(2026, 8, 7),
+        _backfill_symbols=["600000.SH"],
+    )
+    out, _calls, engine = _orchestrated(cfg, monkeypatch, returns=(pl.DataFrame(), []))
+
+    assert out["status"] == "success"
+    assert engine.manifest.get_run(out["run_id"])["status"] == "success"
+
+
+def test_orchestration_all_symbols_failed_warns_and_stays_retryable(tmp_path, monkeypatch):
+    cfg = _orchestrated_cfg(
+        tmp_path,
+        ["600000.SH", "000001.SZ"],
+        _backfill_start=date(2026, 3, 30),
+        _backfill_end=date(2026, 8, 7),
+        _backfill_symbols=["600000.SH", "000001.SZ"],
+    )
+    out, _calls, engine = _orchestrated(
+        cfg, monkeypatch, returns=(pl.DataFrame(), ["600000.SH", "000001.SZ"])
+    )
+
+    assert out["status"] == "warning"
+    assert out["results"][0]["failed_symbols"] == 2
+    assert engine.manifest.get_run(out["run_id"])["status"] == "warning"
+    assert _st_completed_symbols(cfg, out["results"][0]["scope_id"]) == set()  # all retryable
+
+
+def test_cli_partial_failure_exits_nonzero(tmp_path, monkeypatch):
+    """End-to-end CLI: partial ST failure -> JSON status warning + exit 1."""
+    from click.testing import CliRunner
+
+    from ashare_lake.cli.main import cli
+    from ashare_lake.config.bootstrap import path_for_toml
+
+    cfg_path = tmp_path / "test.toml"
+    cfg_path.write_text(
+        f"""
+[data]
+root = "{path_for_toml(tmp_path / "data")}"
+
+[orchestrator]
+workers = 1
+
+[tdx_protocol]
+allow_mock = true
+
+[[job.daily.waves]]
+name = "bars"
+parallel = false
+steps = ["daily_bars"]
+"""
+    )
+    _orchestrated_cfg(
+        tmp_path,
+        ["600000.SH", "000001.SZ"],
+        _backfill_start=date(2026, 3, 30),
+        _backfill_end=date(2026, 8, 7),
+        _backfill_symbols=["600000.SH", "000001.SZ"],
+    )
+    df = pl.DataFrame([_st_row("600000.SH", date(2026, 5, 6))])
+
+    def fake_fetch(symbols, start, end, **kwargs):
+        return df, ["000001.SZ"]
+
+    monkeypatch.setattr("ashare_lake.adapters.baostock.st_history.fetch_st_history", fake_fetch)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "backfill",
+            "trading_status",
+            "--config",
+            str(cfg_path),
+            "--start",
+            "2026-03-30",
+            "--end",
+            "2026-08-07",
+            "--symbols",
+            "600000.SH,000001.SZ",
+        ],
+    )
+
+    assert result.exit_code != 0
+    payload = json.loads(
+        result.output[result.output.rindex("\n{") + 1 : result.output.rindex("}") + 1]
+    )
+    assert payload["status"] == "warning"
+    assert payload["results"][0]["failed_symbols"] == 1


### PR DESCRIPTION
## ST readiness series (human-approved convergence follow-up)

- Branch: `fix/asl-historical-st-negative-evidence-v01` (fork Luke808real), head `0f16f39`
- Delivers: persist historical non-ST evidence; surface partial ST backfill failures; safe backfill scoping; prefer PIT suspension over stale status snapshots; distinguish formal delisting from window overlap
- Goal: enable the ST_READY / PROVENANCE_GAP / PRODUCTION_CUTOVER authority gates closure for the architecture convergence (R8 legacy retirement depends on it)
- No strategy semantics; data-layer only. Maintainer merge requested.