### PR TITLE
fix(tdx): filter unlisted instruments and bound retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **TDX instrument discovery excludes unlisted exchange placeholders.** SH/SZ
+  security lists can advertise IPO and fund-application codes with a positive
+  sub-tick `pre_close` sentinel. Those rows are now excluded before they enter
+  the instrument universe and generate guaranteed-empty daily-bar batches.
+- **Transient worker failures consume a durable, bounded retry budget.** Batch
+  restarts no longer reset `retry_count`; one retry/resume invocation repeats
+  network-failed worker batches with configured pacing until they recover or
+  reach `max_retries`, and reports exhausted batches explicitly.
+
 ## [0.7.3] — 2026-08-23
 
 ### Added

--- a/src/cnequity/adapters/tdx_protocol/client.py
+++ b/src/cnequity/adapters/tdx_protocol/client.py
@@ -76,6 +76,10 @@ _TDX_MAX_CANDIDATES = 16
 _TDX_PROBE_CONCURRENCY = 8  # parallel probes; first live responder wins
 _TDX_FETCH_ATTEMPTS = 3  # server rotations before a bar fetch fails loud
 _TDX_SYMBOL_REQUEST_TIMEOUT_SECONDS = 30.0
+# TDX exposes not-yet-listed stock/fund placeholders with a tiny positive
+# ``pre_close`` sentinel (observed as 5.877471754111438e-39).  The smallest
+# valid price tick for the supported SH/SZ stock and ETF universe is 0.001.
+_TDX_MIN_LISTED_PRE_CLOSE = 0.001
 
 
 def reset_tdx_server_cache() -> None:
@@ -261,6 +265,14 @@ def _filter_instrument_frame(pdf: pl.DataFrame, exch: str) -> pl.DataFrame:
     mask = mask & valid_codes
     for blocked in range(81, 90):
         mask = mask & ~codes.str.starts_with(str(blocked))
+    if "pre_close" in pdf.columns:
+        pre_close = pdf["pre_close"].cast(pl.Float64, strict=False)
+        # Keep nulls for compatibility with alternate clients/fixtures that do
+        # not populate this optional field.  TDX's explicit sub-tick sentinel,
+        # however, means the security is advertised but not listed/tradable.
+        mask = mask & (
+            pre_close.is_null() | (pre_close.is_finite() & (pre_close >= _TDX_MIN_LISTED_PRE_CLOSE))
+        )
     filtered = pdf.filter(mask)
     if filtered.is_empty():
         return pl.DataFrame(

--- a/src/cnequity/orchestrator/engine.py
+++ b/src/cnequity/orchestrator/engine.py
@@ -33,6 +33,22 @@ from cnequity.steps.common import is_trading_day
 
 logger = logging.getLogger(__name__)
 
+_TRANSIENT_RETRY_MARKERS = (
+    "connection",
+    "network",
+    "server",
+    "socket",
+    "temporarily unavailable",
+    "tdx fetch failed",
+    "timed out",
+    "timeout",
+)
+
+
+def _is_transient_retry_error(error_message: str | None) -> bool:
+    message = (error_message or "").lower()
+    return any(marker in message for marker in _TRANSIENT_RETRY_MARKERS)
+
 
 def _has_partial_failures(result: dict[str, Any]) -> bool:
     """Return whether a step reported an incomplete or failed scope.
@@ -488,6 +504,29 @@ class JobEngine:
             )
         return specs
 
+    def _retryable_batches_with_worker_budget(self, run_id: str) -> list:
+        """Apply the durable cap only where retries reuse one batch identity.
+
+        Worker retries restart the same batch id, so ``retry_count`` is a
+        stable logical-attempt budget. Non-worker steps create a new UUID and
+        rely on retry lineage to supersede every predecessor after success;
+        filtering those predecessors by a per-row count could strand one.
+        """
+        return [
+            batch
+            for batch in self.manifest.get_retryable_batches(run_id)
+            if not get_step(batch["task_id"]).requires_workers
+            or batch["retry_count"] < self.config.max_retries
+        ]
+
+    def _exhausted_worker_retry_count(self, run_id: str) -> int:
+        return sum(
+            1
+            for batch in self.manifest.get_retryable_batches(run_id)
+            if get_step(batch["task_id"]).requires_workers
+            and batch["retry_count"] >= self.config.max_retries
+        )
+
     def _retry_run(
         self, run_id: str, trade_date: date, *, auto_finalize: bool = True
     ) -> dict[str, Any]:
@@ -496,10 +535,56 @@ class JobEngine:
         # crashed valuation/backfill runs sat until the next daily job.
         self._reconcile_orphans()
         with run_lock(self.config.meta_root, run_id):
-            return self._retry_run_locked(run_id, trade_date, auto_finalize=auto_finalize)
+            retry_passes = 0
+            total_retried = 0
+            all_results: list[dict[str, Any]] = []
+            all_missing_steps: list[str] = []
+            total_stale_marked = 0
+            total_timeout = {"running_to_stale": 0, "stale_to_failed": 0}
+            automatic_batch_ids: set[str] | None = None
+            while True:
+                result = self._retry_run_locked(
+                    run_id,
+                    trade_date,
+                    auto_finalize=auto_finalize,
+                    retry_batch_ids=automatic_batch_ids,
+                )
+                total_retried += int(result.get("retried", 0))
+                all_results.extend(result.get("results", []))
+                all_missing_steps.extend(result.get("missing_steps", []))
+                total_stale_marked += int(result.get("stale_marked_failed", 0))
+                for key in total_timeout:
+                    total_timeout[key] += int(result.get("batch_timeout", {}).get(key, 0))
+                if result.get("retried", 0):
+                    retry_passes += 1
+                if result["status"] not in {"failed", "warning"}:
+                    break
+                remaining = self._retryable_batches_with_worker_budget(run_id)
+                automatic_batch_ids = {
+                    batch["batch_id"]
+                    for batch in remaining
+                    if get_step(batch["task_id"]).requires_workers
+                    and _is_transient_retry_error(batch["error_message"])
+                }
+                if not automatic_batch_ids:
+                    break
+                time.sleep(self.config.retry_backoff_seconds)
+            result["retried"] = total_retried
+            result["retry_passes"] = retry_passes
+            result["results"] = all_results
+            result["missing_steps"] = list(dict.fromkeys(all_missing_steps))
+            result["stale_marked_failed"] = total_stale_marked
+            result["batch_timeout"] = total_timeout
+            result["retry_exhausted"] = self._exhausted_worker_retry_count(run_id)
+            return result
 
     def _retry_run_locked(
-        self, run_id: str, trade_date: date, *, auto_finalize: bool = True
+        self,
+        run_id: str,
+        trade_date: date,
+        *,
+        auto_finalize: bool = True,
+        retry_batch_ids: set[str] | None = None,
     ) -> dict[str, Any]:
         run_meta = self.manifest.get_run_metadata(run_id)
         # The caller (cne retry) has no session date of its own — it passes
@@ -532,12 +617,36 @@ class JobEngine:
             stale_after_seconds=self.config.batch_stale_seconds,
         )
         stale_marked = timeout["running_to_stale"] + timeout["stale_to_failed"]
-        failed = self.manifest.get_retryable_batches(run_id)
-        missing_init = self._missing_init_steps(run_id) if self._is_init_run(run_id) else []
+        failed = self._retryable_batches_with_worker_budget(run_id)
+        if retry_batch_ids is not None:
+            failed = [batch for batch in failed if batch["batch_id"] in retry_batch_ids]
+        missing_init = (
+            self._missing_init_steps(run_id)
+            if retry_batch_ids is None and self._is_init_run(run_id)
+            else []
+        )
 
         if not failed and not missing_init:
             incomplete = self.manifest.incomplete_batch_count(run_id)
             if incomplete > 0:
+                exhausted = self._exhausted_worker_retry_count(run_id)
+                status = self._retry_batch_status(run_id)
+                if exhausted and status in {"failed", "warning"}:
+                    if auto_finalize:
+                        self.manifest.finish_run(run_id, status)
+                    return {
+                        "run_id": run_id,
+                        "status": status,
+                        "retried": 0,
+                        "retry_exhausted": exhausted,
+                        "incomplete_batches": incomplete,
+                        "incomplete_by_status": (
+                            self.manifest.incomplete_batch_counts_by_status(run_id)
+                        ),
+                        "stale_marked_failed": stale_marked,
+                        "batch_timeout": timeout,
+                        "results": [],
+                    }
                 return self._pending_retry_payload(
                     run_id, stale_marked=stale_marked, timeout=timeout
                 )
@@ -572,35 +681,40 @@ class JobEngine:
 
         context = self._merge_retry_context(run_id, trade_date)
 
-        worker_batches_by_dataset: dict[str, list] = defaultdict(list)
-        step_batches_by_dataset: dict[str, list] = defaultdict(list)
+        self.manifest.increment_batch_retry_counts(
+            run_id,
+            [batch["batch_id"] for batch in failed if get_step(batch["task_id"]).requires_workers],
+        )
+
+        worker_batches_by_step: dict[str, list] = defaultdict(list)
+        step_batches_by_step: dict[str, list] = defaultdict(list)
         for batch in failed:
-            dataset = batch["dataset"]
-            if get_step(dataset).requires_workers:
-                worker_batches_by_dataset[dataset].append(batch)
+            step_name = batch["task_id"]
+            if get_step(step_name).requires_workers:
+                worker_batches_by_step[step_name].append(batch)
             else:
-                step_batches_by_dataset[dataset].append(batch)
+                step_batches_by_step[step_name].append(batch)
 
         results: list[dict[str, Any]] = []
         retried = len(failed)
         init_phases = self._init_phases_list(run_id) if self._is_init_run(run_id) else []
 
-        for dataset, worker_batches in worker_batches_by_dataset.items():
+        for step_name, worker_batches in worker_batches_by_step.items():
             context["_retry_batch_specs"] = self._worker_batch_specs(worker_batches, trade_date)
             previous_backfill = self.config._backfill
             if init_phases:
-                self.config._backfill = step_backfill(dataset, init_phases)
+                self.config._backfill = step_backfill(step_name, init_phases)
             try:
-                results.append(self._run_step(dataset, trade_date, run_id, context))
+                results.append(self._run_step(step_name, trade_date, run_id, context))
             finally:
                 self.config._backfill = previous_backfill
                 context.pop("_retry_batch_specs", None)
 
-        for dataset, batches in step_batches_by_dataset.items():
+        for step_name, batches in step_batches_by_step.items():
             previous_backfill = self.config._backfill
             if init_phases:
-                self.config._backfill = step_backfill(dataset, init_phases)
-            if dataset == "corporate_actions":
+                self.config._backfill = step_backfill(step_name, init_phases)
+            if step_name == "corporate_actions":
                 retry_symbols: list[str] = []
                 for batch in batches:
                     retry_symbols.extend(json.loads(batch["symbols_json"] or "[]"))
@@ -609,7 +723,7 @@ class JobEngine:
             try:
                 results.append(
                     self._run_step(
-                        dataset,
+                        step_name,
                         trade_date,
                         run_id,
                         context,

--- a/src/cnequity/orchestrator/manifest.py
+++ b/src/cnequity/orchestrator/manifest.py
@@ -178,11 +178,25 @@ class Manifest:
         with self._connect() as conn:
             conn.execute(
                 """
-                INSERT OR REPLACE INTO ingestion_batches (
+                INSERT INTO ingestion_batches (
                     run_id, batch_id, task_id, dataset, status, symbols_json,
                     window_start, window_end, started_at, heartbeat_at, retry_count,
                     blocks_compaction
                 ) VALUES (?, ?, ?, ?, 'running', ?, ?, ?, ?, ?, 0, ?)
+                ON CONFLICT(run_id, batch_id) DO UPDATE SET
+                    task_id = excluded.task_id,
+                    dataset = excluded.dataset,
+                    status = 'running',
+                    symbols_json = excluded.symbols_json,
+                    window_start = excluded.window_start,
+                    window_end = excluded.window_end,
+                    rows_read = 0,
+                    rows_written = 0,
+                    started_at = excluded.started_at,
+                    finished_at = NULL,
+                    error_message = NULL,
+                    heartbeat_at = excluded.heartbeat_at,
+                    blocks_compaction = excluded.blocks_compaction
                 """,
                 (
                     run_id,
@@ -242,14 +256,14 @@ class Manifest:
         rows_read: int = 0,
         rows_written: int = 0,
         error_message: str | None = None,
-        retry_count: int = 0,
+        retry_count: int | None = None,
     ) -> None:
         with self._connect() as conn:
             conn.execute(
                 """
                 UPDATE ingestion_batches
                 SET status = ?, finished_at = ?, rows_read = ?, rows_written = ?,
-                    error_message = ?, retry_count = ?,
+                    error_message = ?, retry_count = COALESCE(?, retry_count),
                     blocks_compaction = CASE
                         WHEN ? IN ('warning', 'failed', 'stale') THEN 1
                         ELSE blocks_compaction
@@ -324,17 +338,54 @@ class Manifest:
             )
             return cur.rowcount
 
-    def get_retryable_batches(self, run_id: str) -> list[sqlite3.Row]:
+    def increment_batch_retry_counts(self, run_id: str, batch_ids: list[str]) -> int:
+        """Persist one orchestrator retry attempt for each selected batch."""
+        ids = sorted(set(batch_ids))
+        if not ids:
+            return 0
+        placeholders = ",".join("?" for _ in ids)
+        with self._connect() as conn:
+            cur = conn.execute(
+                f"""
+                UPDATE ingestion_batches
+                SET retry_count = retry_count + 1
+                WHERE run_id = ? AND batch_id IN ({placeholders})
+                  AND status IN ('failed', 'warning')
+                """,
+                (run_id, *ids),
+            )
+            return cur.rowcount
+
+    def get_retryable_batches(
+        self, run_id: str, *, max_retries: int | None = None
+    ) -> list[sqlite3.Row]:
+        with self._connect() as conn:
+            retry_clause = "" if max_retries is None else " AND retry_count < ?"
+            params: tuple[object, ...] = (run_id,)
+            if max_retries is not None:
+                params += (max_retries,)
+            cur = conn.execute(
+                f"""
+                SELECT * FROM ingestion_batches
+                WHERE run_id = ? AND status IN ('failed', 'warning')
+                {retry_clause}
+                ORDER BY started_at, batch_id
+                """,
+                params,
+            )
+            return cur.fetchall()
+
+    def exhausted_retry_count(self, run_id: str, *, max_retries: int) -> int:
         with self._connect() as conn:
             cur = conn.execute(
                 """
-                SELECT * FROM ingestion_batches
+                SELECT COUNT(*) AS cnt FROM ingestion_batches
                 WHERE run_id = ? AND status IN ('failed', 'warning')
-                ORDER BY started_at, batch_id
+                  AND retry_count >= ?
                 """,
-                (run_id,),
+                (run_id, max_retries),
             )
-            return cur.fetchall()
+            return int(cur.fetchone()["cnt"])
 
     def get_failed_batches(self, run_id: str) -> list[sqlite3.Row]:
         """Backward-compatible alias for every immediately retryable batch."""

--- a/tests/unit/test_batch_lifecycle.py
+++ b/tests/unit/test_batch_lifecycle.py
@@ -74,6 +74,22 @@ def test_late_batch_completion_cannot_resurrect_stale_batch(tmp_path):
     assert batch["rows_written"] == 0
 
 
+def test_retry_count_survives_batch_restart_and_finish(tmp_path):
+    manifest = Manifest(Config(data_root=tmp_path / "data").manifest_path)
+    run_id = "run-retry-count"
+    manifest.start_batch(run_id, "batch-0", "daily_bars", "daily_bars")
+    manifest.finish_batch(run_id, "batch-0", "failed", error_message="timeout")
+    assert manifest.increment_batch_retry_counts(run_id, ["batch-0"]) == 1
+
+    manifest.start_batch(run_id, "batch-0", "daily_bars", "daily_bars")
+    manifest.finish_batch(run_id, "batch-0", "failed", error_message="timeout again")
+
+    batch = manifest.get_batches_for_run(run_id)[0]
+    assert batch["retry_count"] == 1
+    assert manifest.get_retryable_batches(run_id, max_retries=1) == []
+    assert manifest.exhausted_retry_count(run_id, max_retries=1) == 1
+
+
 def test_compact_promotes_stale_running_batch(tmp_path):
     cfg = Config(data_root=tmp_path / "data", batch_stale_seconds=60)
     run_id = "run-compact-stale"

--- a/tests/unit/test_instruments_compact.py
+++ b/tests/unit/test_instruments_compact.py
@@ -591,6 +591,24 @@ def test_tdx_instrument_frame_marks_etf_asset_type():
     assert sz_types == {"000001.SZ": "stock", "159915.SZ": "etf"}
 
 
+def test_tdx_instrument_frame_rejects_unlisted_pre_close_sentinel():
+    from cnequity.adapters.tdx_protocol.client import _filter_instrument_frame
+
+    sentinel = 5.877471754111438e-39
+    out = _filter_instrument_frame(
+        pl.DataFrame(
+            {
+                "code": ["600519", "601123", "510300", "588999"],
+                "name": ["Moutai", "IPO applicant", "HS300", "Fund applicant"],
+                "pre_close": [1418.0, sentinel, 4.2, sentinel],
+            }
+        ),
+        "SH",
+    )
+
+    assert out["symbol"].to_list() == ["600519.SH", "510300.SH"]
+
+
 def test_enrich_instrument_list_dates_fills_nulls(tmp_path, monkeypatch):
     from cnequity.adapters.eastmoney import instruments as em_inst
 

--- a/tests/unit/test_retry_hardening.py
+++ b/tests/unit/test_retry_hardening.py
@@ -66,14 +66,237 @@ def test_retry_uses_the_original_runs_trade_date_not_today(tmp_path, monkeypatch
 
     def fake_run_step(name, trade_date, run_id, context, *, retry_of=None):
         seen_dates.append(trade_date)
+        manifest.start_batch(run_id, "batch-daily_bars", name, name)
+        manifest.finish_batch(run_id, "batch-daily_bars", "success")
         return {"status": "success"}
 
     monkeypatch.setattr(engine, "_run_step", fake_run_step)
+    monkeypatch.setattr(engine, "_run_finalize_steps", lambda *args, **kwargs: [])
 
     # No trade_date passed — mirrors `cne retry --run-id <id>` exactly.
     engine.run_job("retry", run_id=run_id, retry_failed_only=True)
 
     assert seen_dates == [date.fromisoformat(stored_date)]
+
+
+def test_retry_automatically_repeats_with_persisted_budget(tmp_path, monkeypatch):
+    cfg = Config(
+        data_root=tmp_path / "data",
+        tdx_allow_mock=True,
+        max_retries=3,
+        retry_backoff_seconds=0,
+    )
+    init_data_layout(cfg)
+    manifest = Manifest(cfg.manifest_path)
+    run_id = manifest.start_run("daily", {"trade_date": "2024-06-28"})
+    manifest.start_batch(
+        run_id,
+        "batch-daily_bars",
+        "daily_bars",
+        "daily_bars",
+        symbols=["600519.SH"],
+    )
+    manifest.finish_batch(run_id, "batch-daily_bars", "failed", error_message="timeout")
+
+    engine = JobEngine(cfg)
+    attempts = 0
+    timeout_passes = iter(
+        [
+            {"running_to_stale": 1, "stale_to_failed": 0},
+            {"running_to_stale": 0, "stale_to_failed": 2},
+        ]
+    )
+
+    def flaky_run_step(name, trade_date, resumed_run_id, context, *, retry_of=None):
+        nonlocal attempts
+        attempts += 1
+        manifest.start_batch(resumed_run_id, "batch-daily_bars", name, name)
+        status = "success" if attempts == 2 else "failed"
+        manifest.finish_batch(
+            resumed_run_id,
+            "batch-daily_bars",
+            status,
+            error_message=None if status == "success" else "TDX timeout",
+        )
+        return {"status": status}
+
+    monkeypatch.setattr(engine, "_run_step", flaky_run_step)
+    monkeypatch.setattr(engine, "_run_finalize_steps", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        engine.manifest, "advance_batch_timeouts", lambda *args, **kwargs: next(timeout_passes)
+    )
+    result = engine.run_job("retry", run_id=run_id, retry_failed_only=True)
+
+    assert result["status"] == "success"
+    assert result["retry_passes"] == 2
+    assert result["retried"] == 2
+    assert result["retry_exhausted"] == 0
+    assert [item["status"] for item in result["results"]] == ["failed", "success"]
+    assert result["stale_marked_failed"] == 3
+    assert result["batch_timeout"] == {"running_to_stale": 1, "stale_to_failed": 2}
+    assert manifest.get_batches_for_run(run_id)[0]["retry_count"] == 2
+
+
+def test_retry_stops_at_configured_budget(tmp_path, monkeypatch):
+    cfg = Config(
+        data_root=tmp_path / "data",
+        tdx_allow_mock=True,
+        max_retries=2,
+        retry_backoff_seconds=0,
+    )
+    init_data_layout(cfg)
+    manifest = Manifest(cfg.manifest_path)
+    run_id = manifest.start_run("daily", {"trade_date": "2024-06-28"})
+    manifest.start_batch(run_id, "batch-0", "daily_bars", "daily_bars")
+    manifest.finish_batch(run_id, "batch-0", "failed", error_message="timeout")
+
+    engine = JobEngine(cfg)
+    attempts = 0
+
+    def always_fails(name, trade_date, resumed_run_id, context, *, retry_of=None):
+        nonlocal attempts
+        attempts += 1
+        manifest.start_batch(resumed_run_id, "batch-0", name, name)
+        manifest.finish_batch(resumed_run_id, "batch-0", "failed", error_message="timeout")
+        return {"status": "failed"}
+
+    monkeypatch.setattr(engine, "_run_step", always_fails)
+    result = engine.run_job("retry", run_id=run_id, retry_failed_only=True)
+
+    assert attempts == 2
+    assert result["status"] == "failed"
+    assert result["retry_passes"] == 2
+    assert result["retry_exhausted"] == 1
+    assert manifest.get_batches_for_run(run_id)[0]["retry_count"] == 2
+
+    repeated = engine.run_job("retry", run_id=run_id, retry_failed_only=True)
+    assert attempts == 2
+    assert repeated["status"] == "failed"
+    assert repeated["retried"] == 0
+    assert repeated["retry_exhausted"] == 1
+
+
+def test_retry_does_not_automatically_repeat_non_worker_steps(tmp_path, monkeypatch):
+    cfg = Config(
+        data_root=tmp_path / "data",
+        tdx_allow_mock=True,
+        max_retries=3,
+        retry_backoff_seconds=0,
+    )
+    init_data_layout(cfg)
+    manifest = Manifest(cfg.manifest_path)
+    run_id = manifest.start_run("daily", {"trade_date": "2024-06-28"})
+    manifest.start_batch(run_id, "batch-0", "trading_status", "trading_status")
+    manifest.finish_batch(run_id, "batch-0", "failed", error_message="network timeout")
+
+    engine = JobEngine(cfg)
+    attempts = 0
+
+    def still_fails(name, trade_date, resumed_run_id, context, *, retry_of=None):
+        nonlocal attempts
+        attempts += 1
+        return {"status": "failed"}
+
+    monkeypatch.setattr(engine, "_run_step", still_fails)
+    result = engine.run_job("retry", run_id=run_id, retry_failed_only=True)
+
+    assert attempts == 1
+    assert result["status"] == "failed"
+    assert result["retry_passes"] == 1
+    assert manifest.get_batches_for_run(run_id)[0]["retry_count"] == 0
+
+
+def test_non_worker_retry_lineage_remains_recoverable(tmp_path, monkeypatch):
+    cfg = Config(
+        data_root=tmp_path / "data",
+        tdx_allow_mock=True,
+        max_retries=1,
+        retry_backoff_seconds=0,
+    )
+    init_data_layout(cfg)
+    manifest = Manifest(cfg.manifest_path)
+    run_id = manifest.start_run("daily", {"trade_date": "2024-06-28"})
+    manifest.start_batch(run_id, "batch-original", "trading_status", "trading_status")
+    manifest.finish_batch(run_id, "batch-original", "failed", error_message="network timeout")
+
+    engine = JobEngine(cfg)
+    attempts = 0
+
+    def retry_step(name, trade_date, resumed_run_id, context, *, retry_of=None):
+        nonlocal attempts
+        attempts += 1
+        batch_id = f"batch-retry-{attempts}"
+        manifest.start_batch(resumed_run_id, batch_id, name, name)
+        status = "failed" if attempts == 1 else "success"
+        manifest.finish_batch(resumed_run_id, batch_id, status, error_message="timeout")
+        if status == "success":
+            manifest.supersede_batches(
+                resumed_run_id,
+                retry_of or [],
+                superseded_by=batch_id,
+            )
+        return {"status": status}
+
+    monkeypatch.setattr(engine, "_run_step", retry_step)
+    monkeypatch.setattr(engine, "_run_finalize_steps", lambda *args, **kwargs: [])
+
+    first = engine.run_job("retry", run_id=run_id, retry_failed_only=True)
+    assert first["status"] == "failed"
+    second = engine.run_job("retry", run_id=run_id, retry_failed_only=True)
+
+    assert second["status"] == "success"
+    assert attempts == 2
+    statuses = {
+        batch["batch_id"]: batch["status"] for batch in manifest.get_batches_for_run(run_id)
+    }
+    assert statuses == {
+        "batch-original": "superseded",
+        "batch-retry-1": "superseded",
+        "batch-retry-2": "success",
+    }
+
+
+def test_retry_routes_by_task_id_when_physical_dataset_differs(tmp_path, monkeypatch):
+    cfg = Config(
+        data_root=tmp_path / "data",
+        tdx_allow_mock=True,
+        max_retries=1,
+        retry_backoff_seconds=0,
+    )
+    init_data_layout(cfg)
+    manifest = Manifest(cfg.manifest_path)
+    run_id = manifest.start_run("backfill", {"trade_date": "2024-06-28"})
+    manifest.start_batch(
+        run_id,
+        "history-failed",
+        task_id="daily_bars_history",
+        dataset="daily_bars",
+    )
+    manifest.finish_batch(run_id, "history-failed", "failed", error_message="network timeout")
+
+    engine = JobEngine(cfg)
+    seen_steps: list[str] = []
+
+    def recover(name, trade_date, resumed_run_id, context, *, retry_of=None):
+        seen_steps.append(name)
+        manifest.start_batch(resumed_run_id, "history-success", name, "daily_bars")
+        manifest.finish_batch(resumed_run_id, "history-success", "success")
+        manifest.supersede_batches(
+            resumed_run_id,
+            retry_of or [],
+            superseded_by="history-success",
+        )
+        return {"status": "success"}
+
+    monkeypatch.setattr(engine, "_run_step", recover)
+    monkeypatch.setattr(engine, "_run_finalize_steps", lambda *args, **kwargs: [])
+    result = engine.run_job("retry", run_id=run_id, retry_failed_only=True)
+
+    assert result["status"] == "success"
+    assert seen_steps == ["daily_bars_history"]
+    batches = {batch["batch_id"]: batch for batch in manifest.get_batches_for_run(run_id)}
+    assert batches["history-failed"]["status"] == "superseded"
+    assert batches["history-failed"]["retry_count"] == 0
 
 
 def test_worker_batch_specs_reads_manifest_window(tmp_path):


### PR DESCRIPTION
## Summary

- exclude SH/SZ TDX security-list placeholders whose `pre_close` is below the minimum supported market tick; TDX advertises not-yet-listed IPO/fund applicants with the positive sentinel `5.877471754111438e-39`
- preserve worker-batch retry counts across restarts and enforce the configured `max_retries` budget
- automatically repeat only transient worker failures with configured pacing, while preserving complete multi-pass diagnostics and reporting exhausted batches
- route retry classification and invocation by `task_id`, keeping physical `dataset` aliases separate

## Validation

- `ruff format --check .`
- `ruff check .`
- `pytest -q` (2229 passed, 18 deselected)