### PR TITLE
fix(windows): keep published lake identities POSIX

### DIFF
--- a/src/cnequity/storage/revisions.py
+++ b/src/cnequity/storage/revisions.py
@@ -136,7 +136,9 @@ class RevisionStore:
             revision = current + 1
             committed_at = datetime.now(timezone.utc).isoformat()
             revision_id = uuid.uuid4().hex
-            partitions = tuple(sorted({str(Path(item.path).parent) for item in files}))
+            # File records are already POSIX; Path(str).parent would re-inject
+            # Windows separators into the published partition identity.
+            partitions = tuple(sorted({Path(item.path).parent.as_posix() for item in files}))
             receipt = DatasetRevision(
                 dataset=dataset,
                 revision=revision,
@@ -164,7 +166,7 @@ class RevisionStore:
                     "schema_version": schema_version,
                     "contract_fingerprint": contract_fingerprint,
                     "content_digest": receipt.content_digest,
-                    "revision_receipt": str(receipt_path.relative_to(self.meta_root)),
+                    "revision_receipt": receipt_path.relative_to(self.meta_root).as_posix(),
                     "changed_partitions": list(partitions),
                     "updated_at": committed_at,
                 }

--- a/tests/unit/test_backup_meta_script.py
+++ b/tests/unit/test_backup_meta_script.py
@@ -1,9 +1,13 @@
 import sqlite3
 import subprocess
+import sys
 import tarfile
 from pathlib import Path
 
+import pytest
 
+
+@pytest.mark.skipif(sys.platform == "win32", reason="backup_meta.sh is a Unix shell script")
 def test_backup_meta_accepts_relative_root_and_preserves_evidence(tmp_path):
     data_root = tmp_path / "lake"
     meta_root = data_root / "meta"

--- a/tests/unit/test_operational_cli.py
+++ b/tests/unit/test_operational_cli.py
@@ -8,13 +8,14 @@ from click.testing import CliRunner
 
 from cnequity.cli.main import cli
 from cnequity.config import Config
+from cnequity.config.bootstrap import path_for_toml
 from cnequity.orchestrator.manifest import Manifest
 
 
 def _config(tmp_path):
     data = tmp_path / "lake"
     path = tmp_path / "cnequity.toml"
-    path.write_text(f'[data]\nroot = "{data}"\n', encoding="utf-8")
+    path.write_text(f'[data]\nroot = "{path_for_toml(data)}"\n', encoding="utf-8")
     return Config(data_root=data), path
 
 

--- a/tests/unit/test_revisions.py
+++ b/tests/unit/test_revisions.py
@@ -37,6 +37,9 @@ def test_revision_commit_publishes_receipt_and_state(tmp_path):
     assert receipt.files[0].size_bytes == len(b"first")
     state = store.state.get_payload("daily_bars")
     assert state["revision"] == 1
+    assert state["revision_receipt"] == (
+        f"revisions/daily_bars/{receipt.revision:08d}-{receipt.revision_id}.json"
+    )
     assert state["revision_id"] == receipt.revision_id
     assert state["content_digest"] == receipt.content_digest
     assert store.latest("daily_bars") == receipt


### PR DESCRIPTION
## Summary
- Publish revision partitions and receipt paths with `as_posix()` so Windows does not store `daily_bars\\trade_date=…` identities.
- Write operational CLI test configs through `path_for_toml` so `C:\Users\…` is not parsed as a TOML hex escape.
- Skip `backup_meta.sh` on Windows; it is a Unix shell script and cannot be exec'd as a Win32 binary.

## Test plan
- [x] `pytest tests/unit/test_backup_meta_script.py tests/unit/test_operational_cli.py tests/unit/test_revisions.py`
- [ ] Confirm `test-windows` is green on this PR