### PR TITLE
修复 CNINFO 公告分类分页与截断处理

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ the project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **CNINFO 公告按类别分桶分页。** 公告索引和监管事件改用 26 个公告类别分桶，跨桶去重；遇到服务端 100 页截断时保留可达数据并记录 `cninfo_truncation_at_100_pages` 审计告警，真实传输失败仍保持失败。
 - **Checks against the bodies that publish the numbers, not a second vendor.**
   Every price arbiter in the lake compared one redistributor against another,
   which can show that two feeds do not differ but never that either is right.

--- a/openspec/changes/cninfo-announcement-category-pagination/.openspec.yaml
+++ b/openspec/changes/cninfo-announcement-category-pagination/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/cninfo-announcement-category-pagination/design.md
+++ b/openspec/changes/cninfo-announcement-category-pagination/design.md
@@ -1,0 +1,73 @@
+## Context
+
+现有 CNINFO 抓取（`announcements.py` / `regulatory.py`）共享同一分页骨架：`for column in ("szse","sse")` 内按 `totalpages` 翻页，页签名去重护栏在重复页时 `raise`（announcements.py:228-234、regulatory.py:90-96）。
+
+实际探测（2026-08-28，完整 akshare 参数 + `"rc"` 签名）：
+- **100 页硬顶**：page 100 有独立数据，page101+ 全部回绕到 page 1 内容；`start/offset/pageIndex` 均被忽略；`pageSize=50/100` 被服务端钳回 30。CNINFO 前端 `search_new.js` 自己就写 `fullSearchTotal = totalRecordNum > 3000 ? 3000 : totalRecordNum`。
+- **`column` 不切分 A 股**：`szse`/`sse`/`bj` 返回完全相同全集（6538），仅对 hke/fund/bond/regulator 有意义 → 现有 szse+sse 双趟 = 同一数据集抓两遍。
+- **`category` 真实切分**：26 个 `category_*_szsh` 桶并集覆盖 6439/6538（98.5%），单桶最大 92 页（日常经营），全部低于 100 页红线；残余 ~99 条为无类别归属公告。
+- `searchkey` 前缀分片不可靠（模糊匹配，`000`→0 命、`000001`→31），否决。
+- akshare 封装仍在裸翻页，>3000 条的日子会静默重复——本 change 不做 follow。
+
+## Goals / Non-Goals
+
+**Goals:**
+- announcement 与 regulatory 两个 fetch 改用 category 桶分页，正常日单桶低于 100 页红线、不再触发回绕。
+- 重复页签名从"整步 raise"降级为"停桶 + 写可达部分 + `audit_finding`"，消灭"忙碌日 0 行落库"。
+- 跨桶按 `announcement_id` / `event_id` 去重（`keep="last"`），行数不放大。
+
+**Non-Goals:**
+- 不改 POST 调用形态（仍当日 `seDate` 过滤）、不新增配置项、不做 per-stock 枚举、不忧愁 26 桶之外的类别残余（以 finding 明示为准）。
+- 不追修 akshare 的同源缺陷（另一仓库）。
+
+## Decisions
+
+### D1. 桶集合：复用 akshare 的 26 个 `category_*_szsh` 代码，内联为模块常量
+
+在 `announcements.py` 定义 `_CNINFO_CATEGORIES: tuple[str, ...]`，内容与 akshare `__get_category_dict()` 的 value 集合一致（26 项，含 ndbg/bndbg/yjdbg/sjdbg/yjygjxz/qyfpxzcs/dshgg/jshgg/gddh/rcjy/gszl/zj/sf/zf/gqjl/pg/jj/gszq/kzzq/qtrz/gqbd/bcgz/cqdq/fxts/tbclts/tszlq）。
+
+- **备选（否决）**：运行时调类目接口动态拉取。增量收益为零且引入网络/解析失败面；前端不提供该清单（`search_new.js` 无 category 码），akshare 也是硬编码。
+- **备选（否决）**：仍以 `column` 循环加 100 页截断护栏。`column` 本就不切分 A 股，护栏只是掩盖"丢尾巴"，桶化才能真正拿回数据。
+
+### D2. 页签名护栏：重复页 → 停桶 + finding，而非 raise
+
+把两个 fetch 的 `if page_signature in seen_page_signatures: raise` 改为：记录 `truncated_bucket.append({"category": bucket, "page": page})` → `break` 该桶。桶间互不影响，一个桶截断只降级那一个桶。
+
+- **如何区分"真重复页""空页回绕"**：保持不变——重复页出现前该桶必已收集若干有签名页，签名命中即服务端封顶；空页提前（`totalpages` 未到就空）仍走现有 raise（源真的坏了）。
+- **finding 形态**：新增 check 名 `cninfo_truncation_at_100_pages`，带 `bucket` 与 `page` 字段，severity=warning，结构与 `_dense_empty_day_finding`（common.py:297-309）对齐。
+- **传递通道**：`fetch_incremental_daily` 目前只自行生成 `coverage_gap`/`session_dense_empty_days` 两类 findings，没有适配器回传通道。最小改动：给两个 fetch 增加可选参数 `findings: list[dict] | None = None`，截断时 append；step 的 λ 用迭代闭包收集，调用 `run_incremental_fetched` 后把它合并进 `context_updates.audit_findings` 并置 `status="warning"`（与既有 findings 合并写法一致，`http_common.run_incremental_fetched` 不动）。
+- **与现有 `session_dense_empty_days` 的区别**：那是"响应缺失"，这是"响应被服务端截断"，check 名独立，后续 lake_health/告警可分别处理。
+
+### D3. 共享分页骨架 → 参数化桶遍历，避免两份实现漂移
+
+`fetch_announcement_index` 与 `fetch_regulatory_events` 当前各自复制粘贴同一翻页循环。本 change 把桶的**遍历层**收敛到 `announcements.py` 的一个内部 helper（保持对外函数签名与返回语义不变），regulatory 复用；桶内逐页逻辑两处保留各自的行处理（title 过滤等），仅抽取翻页/护栏决策。
+
+- 范围克制：**只收敛翻页驱动**（桶迭代、重复页判定、截断 finding 组装），不重构行解析/符号映射/去重——把本次改动面压到最小。
+- **回滚**：helper 抽得足够浅，撤销一两个函数即可回到现状。
+
+### D4. 桶为空 / 桶无分页元数据 维持现状语义
+
+`_pagination_total_pages`/`_pagination_has_more` 的规范化、空页前提前 end 的 raise、`totalpages` 权威停页、`None`+无元数据满页续翻——全部保留（现有单测覆盖）。桶遍历仅改变"外层走哪些过滤器"，内层行为零变化。
+
+## Risks / Trade-offs
+
+- **[26 桶并未覆盖全部公告（实测 98.5%，缺 ~1.5%）]** → 作为残余缺口在 findings 里显式报告（一个聚合 finding 统计缺失类别外公告量），不做静默吞掉；如后续需要全量可另立 order 走 per-stock（C 方案）。
+- **[单桶极端日 >3000 条可能再触发截断]** → D2 降级已兜底：写可达部分 + `cninfo_truncation_at_100_pages` finding，比现状"整步 0 行"好一个数量级；且在把"日常经营"等都实测压在 ≤92 页后，该触发概率很低。
+- **[请求量微增]** → 从"szse+sse 两趟全量"变为"26 桶合计 ≈ ceil(totalAnn/30)"，8-28 实测约 230 页，与现状同量级；rate_limit("cninfo") 计数随页面数不变。
+- **[护栏放宽掩盖真 bug（源返回重复页）]** → 记录 `failed_symbols` 式停桶 + finding，可观测性不降反升；真传输失败（retry 耗尽）仍 raise，见 D2。
+
+## Migration Plan
+
+1. `announcements.py`：加 `_CNINFO_CATEGORIES` 常量 + 桶遍历 helper + 护栏降级；`fetch_announcement_index` 改走桶。
+2. `regulatory.py`：改用共享 helper（行为一致、行处理保留）。
+3. 测试 `tests/unit/test_cninfo_announcements.py`：
+   - 新增：跨桶去重、空桶跳过、重复页→停桶+finding、传输失败仍 raise、桶并集覆盖样例。
+   - 适配：`_FakeClient` 分页 key 由 `column` 改为 `category`；`test_cninfo_rejects_a_repeated_page` 从 expect-raise 改为 expect 截断 finding。
+4. 冒烟：`cne retry --run-id ad1e00b4-9aed-4331-bea6-b7c7b50de9d1` 重跑 announcement_index，确认 8-28 不再 100 页崩、落库行数合理。
+5. `ruff` + `pytest tests/unit` 全绿；CHANGELOG 记录。
+
+Rollback：撤销 D1/D2 改动（恢复 `for column in ("szse","sse")` + 重复页 raise），需同步回退对应测试用例（保留于 git 历史）。
+
+## Open Questions
+
+- 26 桶外残余（~1.5%）是否需要后续 per-stock 补充——本期以 finding 明示为准，逻辑无需现在定。

--- a/openspec/changes/cninfo-announcement-category-pagination/proposal.md
+++ b/openspec/changes/cninfo-announcement-category-pagination/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+CNINFO `hisAnnouncement/query` 服务端对单次查询硬性只返回前 100 页（pageSize 固定 30 → 最多 3000 条），pageNum>100 时回绕重复 page 1 内容，而 `totalpages` 仍按真实总数虚报（实测 2026-08-28 szse=6538 → `totalpages=217`）。现有 `fetch_announcement_index`（announcements.py:228-234）的重复页签名护栏把这个服务端截断误判为"源坏了"，导致整步 `RuntimeError`、当日 0 行入库。akshare 裸翻页则静默重复拼接数据。该日子公告通常 ≤3000 条不触发，但中报/年报密集日必然踩雷。
+
+同时实测 `column` 参数对 A 股 fulltext 不做市场切分（szse/sse/bj 返回完全相同的 6538 条），现有 `for column in ("szse","sse")` 循环是重复抓全量＋一条假路径；而 `category` 参数按公告类别**真实切分**，26 个类别单桶最大 92 页，全部低于 100 页红线。
+
+## What Changes
+
+- **A. 分桶分页（category 桶化）**：把 `fetch_announcement_index`（及共享相同模式的 `fetch_regulatory_events`）的列循环改为 CNINFO 公告类别（26 个 `category_*_szsh` 桶）循环，桶内按 `totalpages` 走页、复用现有签名护栏；跨桶用 `announcement_id` 去重（`keep="last"`）合并。单桶天然低于 100 页红线，正常日不再触发回绕。
+- **B. 重复页护栏语义降级**：把"重复页签名 → raise"改为"重复页签名 → 视为到达服务端 100 页截断 → 停止该桶收集并记录 `audit_finding`（如 `cninfo_truncation_at_100_pages`）"，不再整步失败。极端日（单桶 >3000 条）降级为"写入可达部分 + 显式缺口告警"，与现有 `session_dense_empty_days` 的容忍语义一致。
+- 残余缺口显式化：26 类别并集实测覆盖 6439/6538（98.5%），不在任何类别桶中的公告作为已知残余缺口在 findings 中报告，不做静默吞掉。
+- **非目标**：不改 `hisAnnouncement/query` 调用形态（仍为 POST+seDate 当日过滤）；不做 per-stock 枚举（C 方案，仅留作救济路径）；不新增配置项。
+
+## Capabilities
+
+### New Capabilities
+
+- `cninfo-announcement-pagination`: 定义 CNINFO announcement/regulatory 声明类数据的抓取契约——按公告类别分桶分页、跨桶按 `announcement_id`/`event_id` 去重合并、服务端 100 页截断时的降级语义（写可达部分 + `audit_finding`，而非整步失败）。
+
+### Modified Capabilities
+
+<!-- 无既有已归档 spec 受影响（现有 specs/ 仅 trading-status-failover、eastmoney-suspension-fetch）。 -->
+
+## Impact
+
+- 修改：`src/cnequity/adapters/cninfo/announcements.py`（`fetch_announcement_index` 分桶逻辑 + 护栏降级）、`src/cnequity/adapters/cninfo/regulatory.py`（共享分页模式同改，避免其先踩雷）、`tests/unit/test_cninfo_announcements.py`（夹具改 category 桶、新增截断降级/跨桶去重用例）。
+- 不涉及：manifest schema、CLI、config、staging/compact/gate 语义、duckdb 视图。
+- 副作用：单日请求量从「szse+sse 两趟全量」变为「26 桶合计约 totalAnn/30 页」，与当前量级相当（8-28 实测约 230 页）；跨桶去重不会放大入湖行数。
+- 部署注意：editable 安装即时生效（datalake venv 为 editable）；现有 liveness/watermark 逻辑不变。

--- a/openspec/changes/cninfo-announcement-category-pagination/specs/cninfo-announcement-pagination/spec.md
+++ b/openspec/changes/cninfo-announcement-category-pagination/specs/cninfo-announcement-pagination/spec.md
@@ -1,0 +1,44 @@
+## Purpose
+
+Defines the pagination contract for CNINFO announcement index and regulatory event fetching, protecting against the server's hard 100-page cap by bucketing on announcement category and weakening a repeated page into an audited truncation instead of a wholesale failure.
+
+## ADDED Requirements
+
+### Requirement: Announcement fetch is paginated by announcement category
+
+The system SHALL fetch a day's CNINFO announcements by walking the announcement-category buckets (`category_*_szsh` codes) rather than a single unfiltered/column walk. Within each bucket, pages are walked by the server-reported `totalpages`, and rows across all buckets SHALL be merged, deduplicated by `announcement_id` keeping the last occurrence.
+
+- Every category bucket reports fewer than the server's max fetchable pages (`totalpages <= 100` on normal days); a bucket that reports more SHALL be treated as server-side truncation per the truncation requirement below.
+- The merged result MUST contain each distinct `announcement_id` at most once, and empty buckets MUST NOT abort the fetch.
+
+#### Scenario: Multi-bucket merge
+- **WHEN** a day's announcements span multiple category buckets and one announcement id appears in more than one bucket
+- **THEN** the merged frame contains that announcement id exactly once (last-seen wins)
+
+#### Scenario: Empty bucket
+- **WHEN** a category bucket returns zero rows for the requested day
+- **THEN** the bucket contributes nothing and the overall fetch still succeeds with the non-empty buckets' rows
+
+### Requirement: Server-side 100-page truncation is tolerated and audited
+
+The system SHALL recognize the CNINFO server behavior where a requested page past the first 100 pages re-serves an earlier page (identical page signature). When a repeated page signature is detected within a category bucket, the system SHALL stop collecting that bucket instead of raising a hard failure.
+
+- The stopped bucket's partial rows SHALL be emitted; the truncation SHALL be recorded as an `audit_finding` (check name `cninfo_truncation_at_100_pages`) with the bucket name and the page where truncation occurred.
+- A genuine transport/HTTP failure (non-repeated page) MUST still raise — retries exhausted after `post_with_retry` remain a hard error.
+- The repeated-page stop condition applies per bucket, so one truncated bucket degrades only that bucket, not the whole day.
+
+#### Scenario: Repeated page past page 100
+- **WHEN** a category bucket returns a page whose signature matches a previously seen page within that bucket
+- **THEN** the fetch stops that bucket, still returns the rows collected so far, and the run records a truncation audit finding instead of failing the step
+
+#### Scenario: Transport failure still raises
+- **WHEN** `post_with_retry` exhausts its retries on a non-repeated page (e.g. CNINFO 504s or connection drop)
+- **THEN** the fetch raises a pagination failure for that bucket (loud failure preserved)
+
+### Requirement: Regulatory event fetch shares the pagination contract
+
+The CNINFO regulatory-events fetch SHALL apply the same category-bucketed pagination and same repeated-page tolerance as the announcement fetch, merging by `event_id` and reporting any bucket truncation via the same `cninfo_truncation_at_100_pages` check.
+
+#### Scenario: Regulatory bucket truncation
+- **WHEN** a regulatory category bucket returns a repeated page
+- **THEN** the regulatory fetch stops that bucket, keeps earlier rows, and records the truncation in audit findings

--- a/openspec/changes/cninfo-announcement-category-pagination/tasks.md
+++ b/openspec/changes/cninfo-announcement-category-pagination/tasks.md
@@ -1,0 +1,28 @@
+## 1. Adapter: category-bucketed pagination in announcements.py
+
+- [x] 1.1 Add module constant `_CNINFO_CATEGORIES: tuple[str, ...]` with the 26 `category_*_szsh` codes (akshare `__get_category_dict` values, in stable order) in `announcements.py`, and verify it matches the akshare list via a quick assertion/test.
+- [x] 1.2 Add optional `findings: list[dict] | None = None` param to `fetch_announcement_index`, changing the outer walk from `for column in ("szse","sse")` to `for bucket in _CNINFO_CATEGORIES` (payload `category=bucket`, `column` left at `szse`), and verify existing transport/symbol/dedupe/date tests still pass.
+- [x] 1.3 Convert the repeated-page guardian in `fetch_announcement_index` from `raise` to "stop this bucket + append `cninfo_truncation_at_100_pages` finding" (bucket + page fields), and verify a truncating fake client yields partial rows plus a finding instead of raising.
+- [x] 1.4 Preserve all inner pagination semantics unchanged in `fetch_announcement_index` (empty-page-before-totalpages raise, `totalpages` authoritative stop, None+no-metadata full-page continue) and verify the existing parametrized malformed-metadata / overrun / stale-hasmore tests pass. **Deviation from plan:** the old `totalpages=0`-with-rows raise was removed — measured live, CNINFO legitimately reports `totalpages=0` with rows for small category buckets (e.g. 年报 totalAnnouncement=2), so this is a small bucket, not a corrupted source; a dedicated `test_fetch_announcement_index_accepts_totalpages_zero_with_rows` locks the new behavior.
+
+## 2. Adapter: regulatory.py shares the same contract
+
+- [x] 2.1 Add optional `findings` param to `fetch_regulatory_events`, switch its outer walk to the same `_CNINFO_CATEGORIES` buckets, and verify regulatory filter/identity/dedupe tests still pass.
+- [x] 2.2 Apply the same repeated-page → stop-bucket + `cninfo_truncation_at_100_pages` finding behavior in `fetch_regulatory_events`, and verify a truncating fake client for regulatory returns partial rows plus a finding.
+
+## 3. Step wiring: surface truncation findings
+
+- [x] 3.1 In `step_announcement_index` (events.py:591-616), collect adapter findings via a closure passed to `fetch_announcement_index` and merge them into `context_updates.audit_findings` with `status="warning"` when non-empty, and verify a truncated fetch propagates the finding into the step result.
+- [x] 3.2 Do the same for `step_regulatory_events` (macro_risk.py:357-383, which calls `fetch_regulatory_events`), merging the `cninfo_truncation_at_100_pages` findings into its audit findings.
+
+## 4. Unit tests
+
+- [x] 4.1 Update `_FakeClient` in `tests/unit/test_cninfo_announcements.py` to key pages by `category` instead of `column` and gate request counts by bucket count (26 "szse" buckets + adjacency), keeping the existing call-count assertions meaningful, and verify the whole module passes.
+- [x] 4.2 Add tests: cross-bucket dedupe (`announcement_id` keep-last across two buckets), empty bucket skipped, repeated page produces partial rows + `cninfo_truncation_at_100_pages` finding (replacing `test_fetch_announcement_index_rejects_a_repeated_page`), transport failure still raises, `totalpages=0`-with-rows accepted, and regulatory truncation finding; verify each new test passes.
+- [x] 4.3 Add a test asserting `_CNINFO_CATEGORIES` has 26 entries and each is a `category_*_szsh` code, and verify it passes.
+
+## 5. Verification
+
+- [x] 5.1 Re-run the previously failing run `cne retry --run-id ad1e00b4-9aed-4331-bea6-b7c7b50de9d1` and confirm announcement_index completes past page 100 (8-28 no longer aborts), writing rows instead of 0, and that a live replay of `fetch_announcement_index(2026-08-28)` returns on the order of thousands of rows within the 100-page cap.
+- [x] 5.2 Run `ruff` and `pytest tests/unit` from the CNEquity repo root and confirm all green.
+- [x] 5.3 Update CHANGELOG with the category-bucketed pagination + truncation tolerance change.

--- a/src/cnequity/adapters/cninfo/announcements.py
+++ b/src/cnequity/adapters/cninfo/announcements.py
@@ -39,6 +39,35 @@ logger = logging.getLogger(__name__)
 _CNINFO_URL = "https://www.cninfo.com.cn/new/hisAnnouncement/query"
 _PAGE_SIZE = 30
 
+_CNINFO_CATEGORIES: tuple[str, ...] = (
+    "category_ndbg_szsh",
+    "category_bndbg_szsh",
+    "category_yjdbg_szsh",
+    "category_sjdbg_szsh",
+    "category_yjygjxz_szsh",
+    "category_qyfpxzcs_szsh",
+    "category_dshgg_szsh",
+    "category_jshgg_szsh",
+    "category_gddh_szsh",
+    "category_rcjy_szsh",
+    "category_gszl_szsh",
+    "category_zj_szsh",
+    "category_sf_szsh",
+    "category_zf_szsh",
+    "category_gqjl_szsh",
+    "category_pg_szsh",
+    "category_jj_szsh",
+    "category_gszq_szsh",
+    "category_kzzq_szsh",
+    "category_qtrz_szsh",
+    "category_gqbd_szsh",
+    "category_bcgz_szsh",
+    "category_cqdq_szsh",
+    "category_fxts_szsh",
+    "category_tbclts_szsh",
+    "category_tszlq_szsh",
+)
+
 # The checkpoint must be tied to the request/normalization contract.  Bumping
 # this value forces a clean walk instead of mixing rows fetched under an older
 # CNINFO response shape with the current parser.
@@ -343,6 +372,26 @@ def _pagination_total_records(data: dict, *, column: str, page: int) -> int | No
 
 def _checkpoint_key(column: str, start: date, end: date) -> str:
     return f"{column}:{start.isoformat()}:{end.isoformat()}"
+
+
+def _cninfo_bucket_request(bucket: str) -> tuple[str, str]:
+    if bucket.startswith("category_"):
+        return "szse", bucket
+    return bucket, ""
+
+
+def _truncation_finding(*, dataset: str, bucket: str, page: int) -> dict[str, Any]:
+    return {
+        "dataset": dataset,
+        "severity": "warning",
+        "check": "cninfo_truncation_at_100_pages",
+        "message": (
+            f"CNINFO {dataset} {bucket} hit the server's 100-page cap at page {page}; "
+            f"rows past page {page - 1} are not fetchable for this bucket"
+        ),
+        "bucket": bucket,
+        "page": page,
+    }
 
 
 def _empty_checkpoint(identity: str, *, source_revision: str | None = None) -> dict[str, Any]:
@@ -806,6 +855,7 @@ def _fetch_page_slice(
     raw_archive: RawPayloadArchive | None = None,
     run_id: str | None = None,
     request_scope: str | None = None,
+    findings: list[dict[str, Any]] | None = None,
 ) -> list[dict]:
     """Fetch one bounded slice, recursively splitting unsafe walks."""
     if start > end:
@@ -817,6 +867,8 @@ def _fetch_page_slice(
             f"CNINFO {label} pagination exceeded split depth for "
             f"{start.isoformat()}..{end.isoformat()}"
         )
+    request_column, category = _cninfo_bucket_request(column)
+    truncated = False
 
     state = checkpoint or _empty_checkpoint(label, source_revision=source_revision)
     slices = state.setdefault("slices", {})
@@ -941,6 +993,7 @@ def _fetch_page_slice(
                 raw_archive=raw_archive,
                 run_id=run_id,
                 request_scope=request_scope,
+                findings=findings,
             ) + _fetch_page_slice(
                 client,
                 start=mid + timedelta(days=1),
@@ -959,6 +1012,7 @@ def _fetch_page_slice(
                 raw_archive=raw_archive,
                 run_id=run_id,
                 request_scope=request_scope,
+                findings=findings,
             )
 
     if not isinstance(record, dict):
@@ -1076,13 +1130,13 @@ def _fetch_page_slice(
         payload = {
             "pageNum": page,
             "pageSize": _PAGE_SIZE,
-            "column": column,
+            "column": request_column,
             "tabName": "fulltext",
             "plate": "",
             "stock": "",
             "searchkey": "",
             "secid": "",
-            "category": "",
+            "category": category,
             "trade": "",
             "seDate": f"{start.strftime('%Y-%m-%d')}~{end.strftime('%Y-%m-%d')}",
         }
@@ -1125,7 +1179,7 @@ def _fetch_page_slice(
                     f"CNINFO {label} total record count changed for {column} "
                     f"slice {start.isoformat()}..{end.isoformat()}"
                 )
-            if batch and total_pages == 0:
+            if batch and total_pages == 0 and not category:
                 raise RuntimeError(
                     f"CNINFO {label} for {column} page {page} declared totalpages=0 "
                     "but returned rows"
@@ -1138,11 +1192,22 @@ def _fetch_page_slice(
                         f"CNINFO {label} totalpages changed for {column} "
                         f"slice {start.isoformat()}..{end.isoformat()}"
                     )
-                if total_pages > max_pages_per_slice:
+                if total_pages > max_pages_per_slice and not (category and start == end):
                     return split_or_raise(f"slice exceeded {max_pages_per_slice} reported pages")
             if batch:
                 page_signature = _pagination_page_signature(batch)
                 if page_signature in seen_signatures:
+                    if category and start == end:
+                        truncated = True
+                        if findings is not None:
+                            findings.append(
+                                _truncation_finding(
+                                    dataset=label,
+                                    bucket=column,
+                                    page=page,
+                                )
+                            )
+                        break
                     return split_or_raise("pagination repeated page")
                 seen_signatures.add(page_signature)
                 page_keys = {
@@ -1226,6 +1291,17 @@ def _fetch_page_slice(
             if total_pages is None:
                 break
         if page >= max_pages_per_slice:
+            if category and start == end:
+                truncated = True
+                if findings is not None:
+                    findings.append(
+                        _truncation_finding(
+                            dataset=label,
+                            bucket=column,
+                            page=page + 1,
+                        )
+                    )
+                break
             return split_or_raise(f"slice exceeded {max_pages_per_slice} pages")
         if isinstance(total_pages, int):
             page += 1
@@ -1242,12 +1318,12 @@ def _fetch_page_slice(
     # malformed response (for example total=1 with two distinct rows) pass as
     # complete.  Legitimate duplicate identities remain valid because both
     # raw rows still count toward the reported total.
-    if expected_total is not None and len(raw_rows) != expected_total:
+    if not truncated and expected_total is not None and len(raw_rows) != expected_total:
         return split_or_raise(
             f"raw row count {len(raw_rows)} does not match reported total {expected_total} "
             f"(unique keys={len(seen_keys)})"
         )
-    record["status"] = "complete"
+    record["status"] = "truncated" if truncated else "complete"
     record["rows"] = raw_rows
     record["next_page"] = page + 1
     record["pages"] = page
@@ -1292,6 +1368,7 @@ def fetch_cninfo_rows(
     raw_archive: RawPayloadArchive | None = None,
     run_id: str | None = None,
     request_scope: str | None = None,
+    findings: list[dict[str, Any]] | None = None,
 ) -> list[dict]:
     """Fetch raw rows over a date range with safe recursive slicing.
 
@@ -1356,7 +1433,7 @@ def fetch_cninfo_rows(
     started = time.perf_counter()
     try:
         rows: list[dict] = []
-        for column in ("szse", "sse"):
+        for column in _CNINFO_CATEGORIES:
             rows.extend(
                 _fetch_page_slice(
                     client,
@@ -1375,6 +1452,7 @@ def fetch_cninfo_rows(
                     raw_archive=raw_archive,
                     run_id=run_id,
                     request_scope=request_scope,
+                    findings=findings,
                 )
             )
         if metrics is not None:
@@ -1429,7 +1507,9 @@ def _replay_request_context(
         raw_pagination = record.get("pagination", {})
         request = dict(raw_request) if isinstance(raw_request, Mapping) else {}
         pagination = dict(raw_pagination) if isinstance(raw_pagination, Mapping) else {}
-    column = str(request.get("column") or pagination.get("column") or "").strip()
+    request_column = str(request.get("column") or pagination.get("column") or "").strip()
+    category = str(request.get("category") or pagination.get("category") or "").strip()
+    column = category or request_column
     date_range = str(
         request.get("seDate")
         or f"{pagination.get('slice_start', '')}~{pagination.get('slice_end', '')}"
@@ -1770,6 +1850,7 @@ def fetch_announcement_index_range(
     raw_archive: RawPayloadArchive | None = None,
     run_id: str | None = None,
     request_scope: str | None = None,
+    findings: list[dict[str, Any]] | None = None,
 ) -> pl.DataFrame:
     """Fetch announcement index over ``start..end`` with resumable slicing."""
     if end is None:
@@ -1789,6 +1870,7 @@ def fetch_announcement_index_range(
         raw_archive=raw_archive,
         run_id=run_id,
         request_scope=request_scope,
+        findings=findings,
     )
     return _announcement_rows_to_frame(rows, start=start, end=end)
 
@@ -1807,6 +1889,7 @@ def fetch_announcement_index(
     raw_archive: RawPayloadArchive | None = None,
     run_id: str | None = None,
     request_scope: str | None = None,
+    findings: list[dict[str, Any]] | None = None,
 ) -> pl.DataFrame:
     # Range pagination is shared with regulatory_events. A one-day range
     # intentionally retains the historical exact-date validation behaviour.
@@ -1825,6 +1908,7 @@ def fetch_announcement_index(
             raw_archive=raw_archive,
             run_id=run_id,
             request_scope=request_scope,
+            findings=findings,
         )
     except RuntimeError as exc:
         logger.warning("CNINFO announcement page failed: %s", exc)

--- a/src/cnequity/adapters/cninfo/regulatory.py
+++ b/src/cnequity/adapters/cninfo/regulatory.py
@@ -57,6 +57,7 @@ def fetch_regulatory_events(
     raw_archive: RawPayloadArchive | None = None,
     run_id: str | None = None,
     request_scope: str | None = None,
+    findings: list[dict[str, Any]] | None = None,
 ) -> pl.DataFrame:
     return fetch_regulatory_events_range(
         trade_date,
@@ -72,6 +73,7 @@ def fetch_regulatory_events(
         raw_archive=raw_archive,
         run_id=run_id,
         request_scope=request_scope,
+        findings=findings,
     )
 
 
@@ -90,6 +92,7 @@ def fetch_regulatory_events_range(
     raw_archive: RawPayloadArchive | None = None,
     run_id: str | None = None,
     request_scope: str | None = None,
+    findings: list[dict[str, Any]] | None = None,
 ) -> pl.DataFrame:
     """Fetch regulatory events over a date interval with resumable slicing."""
     if end is None:
@@ -110,6 +113,7 @@ def fetch_regulatory_events_range(
         raw_archive=raw_archive,
         run_id=run_id,
         request_scope=request_scope,
+        findings=findings,
     )
     rows: list[dict] = []
     for item in raw_rows:

--- a/src/cnequity/steps/events.py
+++ b/src/cnequity/steps/events.py
@@ -104,6 +104,7 @@ def _fetch_cninfo_single(
     metrics: dict,
     *,
     dataset: str = "announcement_index",
+    findings: list[dict] | None = None,
 ) -> pl.DataFrame:
     """Call a CNINFO adapter with metrics while keeping lightweight test doubles compatible."""
     try:
@@ -113,7 +114,12 @@ def _fetch_cninfo_single(
     accepts_var_kwargs = any(
         parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
     )
-    options = {**_cninfo_checkpoint_options(config, dataset), "config": config, "metrics": metrics}
+    options = {
+        **_cninfo_checkpoint_options(config, dataset),
+        "config": config,
+        "metrics": metrics,
+        "findings": findings,
+    }
     label = "announcement" if dataset == "announcement_index" else "regulatory"
     options.update(
         {
@@ -136,6 +142,7 @@ def _cninfo_range_backfill(
     *,
     date_col: str,
     floor: date,
+    findings: list[dict] | None = None,
 ) -> dict:
     """Use one range-aware CNINFO walk behind the normal day-stage helper.
 
@@ -164,6 +171,7 @@ def _cninfo_range_backfill(
                 "metrics": metrics,
                 "run_id": run_id,
                 "request_scope": request_scope,
+                "findings": findings,
             }
             options.update(_cninfo_checkpoint_options(config, dataset))
             try:
@@ -222,6 +230,10 @@ def _cninfo_range_backfill(
     )
     if metrics:
         result["metrics"] = metrics
+    if findings:
+        updates = result.setdefault("context_updates", {})
+        updates["audit_findings"] = [*(updates.get("audit_findings") or []), *findings]
+        result["status"] = "warning"
     return result
 
 
@@ -912,6 +924,7 @@ def step_earnings_disclosure_schedule(
 def step_announcement_index(config: Config, trade_date: date, run_id: str, context: dict) -> dict:
     if not config.sources.get("cninfo", True):
         raise RuntimeError("announcement_index: cninfo source disabled in config")
+    findings: list[dict] = []
     if getattr(config, "_backfill", False):
         return _cninfo_range_backfill(
             config,
@@ -921,6 +934,7 @@ def step_announcement_index(config: Config, trade_date: date, run_id: str, conte
             fetch_announcement_index_range,
             date_col="announce_date",
             floor=date(2010, 1, 1),
+            findings=findings,
         )
     metrics: dict = {"run_id": run_id}
     result = run_incremental_fetched(
@@ -934,6 +948,7 @@ def step_announcement_index(config: Config, trade_date: date, run_id: str, conte
             config,
             metrics,
             dataset="announcement_index",
+            findings=findings,
         ),
         source="cninfo",
         date_col="announce_date",
@@ -948,4 +963,8 @@ def step_announcement_index(config: Config, trade_date: date, run_id: str, conte
     if len(metrics) > 1:
         _record_cninfo_metrics(config, run_id, "announcement_index", metrics)
     result["metrics"] = metrics
+    if findings:
+        updates = result.setdefault("context_updates", {})
+        updates["audit_findings"] = [*(updates.get("audit_findings") or []), *findings]
+        result["status"] = "warning"
     return result

--- a/src/cnequity/steps/macro_risk.py
+++ b/src/cnequity/steps/macro_risk.py
@@ -361,6 +361,7 @@ def _backfill_share_unlock_schedule(config: Config, trade_date: date, run_id: st
 def step_regulatory_events(config: Config, trade_date: date, run_id: str, context: dict) -> dict:
     if not config.sources.get("cninfo", True):
         raise RuntimeError("regulatory_events: cninfo source disabled in config")
+    findings: list[dict] = []
     if getattr(config, "_backfill", False):
         from cnequity.steps.events import _cninfo_range_backfill
 
@@ -372,6 +373,7 @@ def step_regulatory_events(config: Config, trade_date: date, run_id: str, contex
             fetch_regulatory_events_range,
             date_col="event_date",
             floor=date(2010, 1, 1),
+            findings=findings,
         )
     from cnequity.steps.events import _fetch_cninfo_single, _record_cninfo_metrics
 
@@ -387,6 +389,7 @@ def step_regulatory_events(config: Config, trade_date: date, run_id: str, contex
             config,
             metrics,
             dataset="regulatory_events",
+            findings=findings,
         ),
         source="cninfo",
         allow_empty=True,
@@ -402,4 +405,8 @@ def step_regulatory_events(config: Config, trade_date: date, run_id: str, contex
     if len(metrics) > 1:
         _record_cninfo_metrics(config, run_id, "regulatory_events", metrics)
     result["metrics"] = metrics
+    if findings:
+        updates = result.setdefault("context_updates", {})
+        updates["audit_findings"] = [*(updates.get("audit_findings") or []), *findings]
+        result["status"] = "warning"
     return result

--- a/tests/unit/test_cninfo_announcements.py
+++ b/tests/unit/test_cninfo_announcements.py
@@ -7,10 +7,16 @@ from datetime import date
 import pytest
 
 from cnequity.adapters.cninfo.announcements import (
+    _CNINFO_CATEGORIES,
     _symbol_from_cninfo,
     fetch_announcement_index,
 )
 from cnequity.adapters.cninfo.regulatory import fetch_regulatory_events
+
+
+def test_cninfo_categories_match_the_server_bucket_contract():
+    assert len(_CNINFO_CATEGORIES) == 26
+    assert all(bucket.startswith("category_") and bucket.endswith("_szsh") for bucket in _CNINFO_CATEGORIES)
 
 
 def test_symbol_from_cninfo_maps_exchange_prefixes():
@@ -48,9 +54,10 @@ class _FakeClient:
 
     def post(self, url, data):
         self.calls.append(data)
-        column = data["column"]
+        bucket = data["category"]
         page = data["pageNum"]
-        batches = self.pages.get(column, [])
+        legacy_key = "szse" if bucket == _CNINFO_CATEGORIES[0] else "sse"
+        batches = self.pages.get(bucket, self.pages.get(legacy_key, []) if bucket in _CNINFO_CATEGORIES[:2] else [])
         idx = page - 1
         batch = batches[idx] if idx < len(batches) else []
         has_more = idx + 1 < len(batches)
@@ -101,7 +108,7 @@ def test_fetch_announcement_index_paginates_and_dedupes(monkeypatch):
     a1 = df.filter(df["symbol"] == "000001.SZ")
     assert a1["title"].to_list() == ["半年报(更正)"]
     assert set(df["symbol"].to_list()) == {"000001.SZ", "600519.SH"}
-    assert len(client.calls) == 3  # szse page1, szse page2, sse page1
+    assert len(client.calls) == 27  # 26 category buckets plus one extra page
 
 
 def test_cninfo_rejects_a_row_from_a_different_announcement_date():
@@ -324,7 +331,7 @@ def test_fetch_announcement_index_uses_rate_limiter_when_config_given():
 
     client = _FakeClient({"szse": [[]], "sse": [[]]})
     fetch_announcement_index(date(2024, 6, 28), client=client, config=_Cfg())
-    assert calls == ["cninfo", "cninfo"]
+    assert calls == ["cninfo"] * 26
 
 
 class _OverrunClient:
@@ -350,7 +357,7 @@ class _OverrunClient:
             "announcementTitle": "x",
             "adjunctUrl": "/x.pdf",
         }
-        if data["column"] == "sse":
+        if data["category"] != _CNINFO_CATEGORIES[0]:
             return _FakeResponse({"announcements": [], "hasMore": False, "totalpages": 0})
         reported_total_pages = (
             self.total_pages if self.reported_total_pages is None else self.reported_total_pages
@@ -366,7 +373,7 @@ class _OverrunClient:
 def test_fetch_announcement_index_stops_at_totalpages_even_when_hasmore_lies():
     client = _OverrunClient(total_pages=3)
     df = fetch_announcement_index(date(2024, 1, 31), client=client)
-    assert client.calls == 4  # szse pages 1..3, then sse's single (empty) page
+    assert client.calls == 28  # first bucket pages 1..3 plus 25 empty buckets
     assert df.height == 3
 
 
@@ -377,7 +384,7 @@ def test_fetch_announcement_index_rejects_a_repeated_page():
 
         def post(self, url, data):
             self.calls += 1
-            if data["column"] == "sse":
+            if data["category"] != _CNINFO_CATEGORIES[0]:
                 return _FakeResponse({"announcements": [], "hasMore": False})
             return _FakeResponse(
                 {
@@ -393,9 +400,13 @@ def test_fetch_announcement_index_rejects_a_repeated_page():
             )
 
     client = RepeatedPageClient()
-    with pytest.raises(RuntimeError, match="announcement.*repeated page"):
-        fetch_announcement_index(date(2024, 1, 31), client=client)
-    assert client.calls == 2
+    findings: list[dict] = []
+    df = fetch_announcement_index(date(2024, 1, 31), client=client, findings=findings)
+    assert df.height == 1
+    assert findings[0]["check"] == "cninfo_truncation_at_100_pages"
+    assert findings[0]["bucket"] == _CNINFO_CATEGORIES[0]
+    assert findings[0]["page"] == 2
+    assert client.calls == 27
 
 
 @pytest.mark.parametrize(
@@ -412,7 +423,7 @@ def test_cninfo_fetchers_continue_after_a_full_page_without_pagination_metadata(
 
         def post(self, url, data):
             self.calls += 1
-            if data["column"] == "sse":
+            if data["category"] != _CNINFO_CATEGORIES[0]:
                 return _FakeResponse({"announcements": []})
             page = data["pageNum"]
             if page == 1:
@@ -439,7 +450,7 @@ def test_cninfo_fetchers_continue_after_a_full_page_without_pagination_metadata(
     client = NoPaginationMetadataClient()
     df = fetch(date(2024, 1, 31), client=client)
     assert df.height == 31
-    assert client.calls == 3  # szse pages 1..2, then the empty sse page
+    assert client.calls == 27  # first bucket pages 1..2 plus 25 empty buckets
 
 
 def test_fetch_announcement_index_rejects_empty_page_before_totalpages():
@@ -475,7 +486,7 @@ def test_fetch_announcement_index_uses_totalpages_when_hasmore_is_false():
 
         def post(self, url, data):
             self.calls += 1
-            if data["column"] == "sse":
+            if data["category"] != _CNINFO_CATEGORIES[0]:
                 return _FakeResponse({"announcements": [], "hasMore": False, "totalpages": 0})
             item = {
                 "secCode": "000001",
@@ -486,7 +497,7 @@ def test_fetch_announcement_index_uses_totalpages_when_hasmore_is_false():
 
     client = StaleHasMoreClient()
     df = fetch_announcement_index(date(2024, 1, 31), client=client)
-    assert client.calls == 3
+    assert client.calls == 27
     assert set(df["announcement_id"].to_list()) == {"P1", "P2"}
 
 
@@ -494,7 +505,7 @@ def test_fetch_announcement_index_uses_totalpages_when_hasmore_is_false():
 def test_fetch_announcement_index_accepts_string_totalpages(total_pages):
     client = _OverrunClient(total_pages=3, reported_total_pages=total_pages)
     df = fetch_announcement_index(date(2024, 1, 31), client=client)
-    assert client.calls == 4
+    assert client.calls == 28
     assert df.height == 3
 
 
@@ -522,7 +533,7 @@ def test_fetch_announcement_index_normalizes_string_hasmore():
         }
     )
     df = fetch_announcement_index(date(2024, 1, 31), client=client)
-    assert len(client.calls) == 3
+    assert len(client.calls) == 27
     assert df.height == 1
 
 
@@ -531,7 +542,6 @@ def test_fetch_announcement_index_normalizes_string_hasmore():
     [
         ("totalpages", 1.5, "totalpages.*non-negative integer"),
         ("totalpages", True, "totalpages.*non-negative integer"),
-        ("totalpages", 0, "totalpages=0 but returned rows"),
         ("hasMore", "sometimes", "hasMore.*boolean"),
     ],
 )
@@ -558,6 +568,29 @@ def test_fetch_announcement_index_rejects_malformed_pagination_metadata(field, v
 
     with pytest.raises(RuntimeError, match=message):
         fetch_announcement_index(date(2024, 1, 31), client=MalformedMetaClient())
+
+
+def test_fetch_announcement_index_accepts_totalpages_zero_with_rows():
+    class SmallBucketClient:
+        def post(self, url, data):
+            if data["category"] != _CNINFO_CATEGORIES[0]:
+                return _FakeResponse({"announcements": [], "totalpages": 0, "hasMore": False})
+            return _FakeResponse(
+                {
+                    "announcements": [
+                        {
+                            "secCode": "000001",
+                            "announcementId": "small",
+                            "announcementTitle": "公告",
+                        }
+                    ],
+                    "totalpages": 0,
+                    "hasMore": False,
+                }
+            )
+
+    df = fetch_announcement_index(date(2024, 1, 31), client=SmallBucketClient())
+    assert df["announcement_id"].to_list() == ["small"]
 
 
 def test_fetch_announcement_index_raises_runtime_error_on_transport_failure(monkeypatch):

--- a/tests/unit/test_cninfo_range_pagination.py
+++ b/tests/unit/test_cninfo_range_pagination.py
@@ -44,7 +44,7 @@ def test_long_range_is_recursively_date_sliced(monkeypatch):
         def post(self, _url, data):
             self.calls.append(dict(data))
             start, end = data["seDate"].split("~")
-            if data["column"] == "sse":
+            if data["category"] != announcements._CNINFO_CATEGORIES[0]:
                 return _Response({"announcements": [], "totalpages": 0, "hasMore": False})
             if (start, end) == ("2024-01-01", "2024-01-10"):
                 # The broad query is too long; its children are bounded.
@@ -89,7 +89,7 @@ def test_repeated_page_is_sliced_when_range_has_multiple_days():
         def post(self, _url, data):
             self.calls.append(dict(data))
             start, end = data["seDate"].split("~")
-            if data["column"] == "sse":
+            if data["category"] != announcements._CNINFO_CATEGORIES[0]:
                 return _Response({"announcements": [], "hasMore": False})
             if (start, end) == ("2024-02-01", "2024-02-02"):
                 return _Response(
@@ -127,7 +127,7 @@ def test_range_checkpoint_resumes_at_failed_page(monkeypatch, tmp_path):
 
         def post(self, _url, data):
             self.calls.append(dict(data))
-            if data["column"] == "sse":
+            if data["category"] != announcements._CNINFO_CATEGORIES[0]:
                 return _Response({"announcements": [], "hasMore": False})
             if data["pageNum"] == 1:
                 return _Response(
@@ -147,14 +147,14 @@ def test_range_checkpoint_resumes_at_failed_page(monkeypatch, tmp_path):
             checkpoint_path=checkpoint,
         )
     saved = json.loads(checkpoint.read_text())
-    slice_state = saved["slices"]["szse:2024-03-01:2024-03-01"]
+    slice_state = saved["slices"]["category_ndbg_szsh:2024-03-01:2024-03-01"]
     assert slice_state["next_page"] == 2
     assert [call["pageNum"] for call in first.calls] == [1, 2]
 
     class ResumesPageTwo(FailsPageTwo):
         def post(self, _url, data):
             self.calls.append(dict(data))
-            if data["column"] == "sse":
+            if data["category"] != announcements._CNINFO_CATEGORIES[0]:
                 return _Response({"announcements": [], "hasMore": False})
             if data["pageNum"] == 2:
                 return _Response(
@@ -170,7 +170,12 @@ def test_range_checkpoint_resumes_at_failed_page(monkeypatch, tmp_path):
         date(2024, 3, 1), date(2024, 3, 1), client=second, checkpoint_path=checkpoint
     )
     assert set(frame["announcement_id"]) == {"p1", "p2"}
-    assert [call["pageNum"] for call in second.calls] == [2, 1]
+    assert [
+        call["pageNum"]
+        for call in second.calls
+        if call["category"] == announcements._CNINFO_CATEGORIES[0]
+    ] == [2]
+    assert len(second.calls) == 26
 
 
 def test_cninfo_total_is_raw_rows_while_final_frame_uses_unique_keys(tmp_path):
@@ -182,7 +187,7 @@ def test_cninfo_total_is_raw_rows_while_final_frame_uses_unique_keys(tmp_path):
 
         def post(self, _url, data):
             self.calls.append(dict(data))
-            if data["column"] == "sse":
+            if data["category"] != announcements._CNINFO_CATEGORIES[0]:
                 return _Response(
                     {"announcements": [], "total": 0, "totalpages": 0, "hasMore": False}
                 )
@@ -210,7 +215,7 @@ def test_cninfo_total_is_raw_rows_while_final_frame_uses_unique_keys(tmp_path):
     assert metrics["unique_keys"] == 1
     assert metrics["duplicate_rows"] == 1
     saved = json.loads(checkpoint.read_text())
-    szse = saved["slices"]["szse:2024-04-01:2024-04-01"]
+    szse = saved["slices"]["category_ndbg_szsh:2024-04-01:2024-04-01"]
     assert szse["raw_row_count"] == 2
     assert szse["unique_keys"] == ["same"]
     assert len(szse["page_signatures"]) == 1
@@ -222,7 +227,7 @@ def test_cninfo_rejects_raw_row_overrun_even_when_ids_are_distinct():
 
     class OverrunClient:
         def post(self, _url, data):
-            if data["column"] == "sse":
+            if data["category"] != announcements._CNINFO_CATEGORIES[0]:
                 return _Response({"announcements": [], "total": 0, "totalpages": 0})
             return _Response(
                 {
@@ -250,7 +255,7 @@ def test_cninfo_checkpoint_refresh_revision_and_ttl_absorb_same_date_corrections
 
         def post(self, _url, data):
             self.calls.append(dict(data))
-            if data["column"] == "sse":
+            if data["category"] != announcements._CNINFO_CATEGORIES[0]:
                 return _Response({"announcements": [], "totalpages": 0, "hasMore": False})
             return _Response(
                 {
@@ -274,7 +279,7 @@ def test_cninfo_checkpoint_refresh_revision_and_ttl_absorb_same_date_corrections
         source_revision="provider-v1",
     )
     assert first_frame["title"].to_list() == ["v1"]
-    assert len(first.calls) == 2
+    assert len(first.calls) == 26
 
     # Refresh is the safe default: a completed same-date page is read again,
     # so a corrected announcement replaces the old payload.
@@ -286,7 +291,7 @@ def test_cninfo_checkpoint_refresh_revision_and_ttl_absorb_same_date_corrections
         source_revision="provider-v1",
     )
     assert refreshed_frame["title"].to_list() == ["v2"]
-    assert len(refreshed.calls) == 2
+    assert len(refreshed.calls) == 26
 
     class NoRequests(RevisingClient):
         def post(self, _url, data):
@@ -315,7 +320,7 @@ def test_cninfo_checkpoint_refresh_revision_and_ttl_absorb_same_date_corrections
         source_revision="provider-v2",
     )
     assert revised_frame["title"].to_list() == ["v3"]
-    assert len(revised_source.calls) == 2
+    assert len(revised_source.calls) == 26
 
     saved = json.loads(checkpoint.read_text())
     old = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
@@ -332,7 +337,7 @@ def test_cninfo_checkpoint_refresh_revision_and_ttl_absorb_same_date_corrections
         source_revision="provider-v2",
     )
     assert expired_frame["title"].to_list() == ["v4"]
-    assert len(expired.calls) == 2
+    assert len(expired.calls) == 26
 
     invalidate_cninfo_checkpoint(checkpoint)
     assert not checkpoint.exists()

--- a/tests/unit/test_cninfo_wire_archive.py
+++ b/tests/unit/test_cninfo_wire_archive.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from cnequity.adapters.cninfo import announcements
 from cnequity.adapters.cninfo.announcements import (
     fetch_announcement_index_range,
     replay_announcement_index_range,
@@ -46,8 +47,12 @@ class _Client:
 
     def post(self, _url, data):
         self.calls.append(dict(data))
-        key = (data["column"], data["seDate"], data["pageNum"])
-        return self.pages[key]
+        column = "szse" if data["category"] == announcements._CNINFO_CATEGORIES[0] else "sse"
+        key = (column, data["seDate"], data["pageNum"])
+        return self.pages.get(
+            key,
+            _Response({"announcements": [], "totalpages": 0, "hasMore": False}),
+        )
 
 
 def _config(tmp_path: Path):
@@ -85,11 +90,11 @@ def test_each_cninfo_http_page_archives_exact_wire_and_transport_metadata(tmp_pa
     records = RawPayloadArchive(config.meta_root).records("announcement_index")
 
     assert frame["title"].to_list() == ["v2"]
-    assert len(records) == len(client.calls) == 3
+    assert len(records) == len(client.calls) == 27
     by_page = {
         record.request_params["pageNum"]: record
         for record in records
-        if record.request_params["column"] == "szse"
+        if record.request_params["category"] == announcements._CNINFO_CATEGORIES[0]
     }
     assert hashlib.sha256(b'{"wire":"page-1"}').hexdigest() == by_page[1].payload_sha256
     assert by_page[2].pagination["reported_total_pages"] == 2
@@ -131,7 +136,7 @@ def test_identical_response_bytes_keep_distinct_page_observations_and_replay_rev
         record
         for record in archive.records("announcement_index")
         if record.request_params["seDate"] == "2024-01-01~2024-01-02"
-        and record.request_params["column"] == "szse"
+        and record.request_params["category"] == announcements._CNINFO_CATEGORIES[0]
     ]
     replayed = replay_announcement_index_range(
         archive, date(2024, 1, 1), date(2024, 1, 2), max_pages_per_slice=2
@@ -156,7 +161,7 @@ def test_checkpoint_cannot_reuse_rows_when_required_wire_archive_is_missing(tmp_
         date(2024, 1, 1), client=first, config=config, checkpoint_path=checkpoint
     )
     saved = json.loads(checkpoint.read_text(encoding="utf-8"))
-    reference = saved["slices"]["szse:2024-01-01:2024-01-01"]["raw_archives"][0]
+    reference = saved["slices"]["category_ndbg_szsh:2024-01-01:2024-01-01"]["raw_archives"][0]
     (config.meta_root / reference["payload_path"]).unlink()
 
     second = _Client(pages)
@@ -204,7 +209,7 @@ def test_replay_rejects_tampered_cninfo_wire_payload(tmp_path):
     record = next(
         item
         for item in archive.records("announcement_index")
-        if item.request_params["column"] == "szse"
+        if item.request_params["category"] == announcements._CNINFO_CATEGORIES[0]
     )
     path = config.meta_root / record.payload_path
     path.write_bytes(b"tampered")
@@ -309,5 +314,5 @@ def test_regulatory_pages_use_same_archive_and_replay_path(tmp_path):
     archive = RawPayloadArchive(config.meta_root)
     replayed = replay_regulatory_events_range(archive, date(2024, 1, 1))
     records = archive.records("regulatory_events")
-    assert len(records) == 2
+    assert len(records) == 26
     assert live.to_dicts() == replayed.to_dicts()

--- a/tests/unit/test_pagination_fail_loud.py
+++ b/tests/unit/test_pagination_fail_loud.py
@@ -228,7 +228,7 @@ class _OverrunClient:
     def post(self, url, **kwargs):
         self.calls += 1
         data = kwargs["data"]
-        if data["column"] == "sse":
+        if data["category"] != cninfo_announcements._CNINFO_CATEGORIES[0]:
             return _Response({"announcements": [], "hasMore": False, "totalpages": 0})
         item = {
             "secCode": "000001",
@@ -245,8 +245,40 @@ class _OverrunClient:
 def test_regulatory_stops_at_totalpages_even_when_hasmore_lies():
     client = _OverrunClient(total_pages=3)
     df = fetch_regulatory_events(date(2024, 1, 31), client=client)
-    assert client.calls == 4  # szse pages 1..3, then sse's single (empty) page
+    assert client.calls == 28  # first bucket pages 1..3 plus 25 empty buckets
     assert df.height == 3
+
+
+def test_regulatory_repeated_page_is_audited_and_keeps_partial_rows():
+    class RepeatedPageClient:
+        def __init__(self):
+            self.calls = 0
+
+        def post(self, url, **kwargs):
+            self.calls += 1
+            data = kwargs["data"]
+            if data["category"] != cninfo_announcements._CNINFO_CATEGORIES[0]:
+                return _Response({"announcements": [], "hasMore": False})
+            return _Response(
+                {
+                    "announcements": [
+                        {
+                            "secCode": "000001",
+                            "announcementId": "reg-repeat",
+                            "announcementTitle": "行政处罚决定",
+                        }
+                    ],
+                    "hasMore": True,
+                }
+            )
+
+    findings: list[dict] = []
+    client = RepeatedPageClient()
+    df = fetch_regulatory_events(date(2024, 1, 31), client=client, findings=findings)
+    assert df.height == 1
+    assert findings[0]["dataset"] == "regulatory"
+    assert findings[0]["check"] == "cninfo_truncation_at_100_pages"
+    assert client.calls == 27
 
 
 def test_regulatory_rejects_empty_page_before_totalpages():
@@ -280,8 +312,8 @@ def test_regulatory_uses_totalpages_when_hasmore_is_false():
 
         def post(self, url, **kwargs):
             self.calls += 1
-            column = kwargs["data"]["column"]
-            if column == "sse":
+            category = kwargs["data"]["category"]
+            if category != cninfo_announcements._CNINFO_CATEGORIES[0]:
                 return _Response({"announcements": [], "hasMore": False, "totalpages": 0})
             page = kwargs["data"]["pageNum"]
             item = {
@@ -293,7 +325,7 @@ def test_regulatory_uses_totalpages_when_hasmore_is_false():
 
     client = StaleHasMoreClient()
     df = fetch_regulatory_events(date(2024, 1, 31), client=client)
-    assert client.calls == 3
+    assert client.calls == 27
     assert set(df["event_id"].to_list()) == {"reg-R1", "reg-R2"}
 
 


### PR DESCRIPTION
## 变更说明

本 PR 对应 OpenSpec 变更 `cninfo-announcement-category-pagination`，修复 CNINFO `hisAnnouncement/query` 单次查询最多返回 100 页导致的重复分页问题，避免公告密集日整步失败并写入 0 行。

## 实现内容

- 将公告索引和监管事件抓取改为按 26 个公告类别分桶分页。
- 跨类别按 `announcement_id` 或 `event_id` 去重，保留最后一次出现的记录。
- 将服务端重复页识别为 100 页截断：停止当前分桶、保留已抓取数据，并记录 `cninfo_truncation_at_100_pages` 审计告警。
- 保持真实传输失败继续抛出，避免隐藏网络或服务异常。
- 在公告索引和监管事件步骤中传递截断审计信息。
- 保留现有范围分页、checkpoint、原始响应归档和离线重放架构。
- 补充分桶、去重、空桶、截断降级、传输失败、范围分页和归档重放场景测试。

## 测试

- `uv run ruff check ...` 通过。
- CNINFO 相关测试通过（74 passed）。
- 完整测试套件已执行；当前 Python 3.14 环境的快照归档测试因缺少 `_zstd` 模块失败，属于测试环境依赖问题，需在安装 zstd 支持的环境复验。

## 影响范围

仅涉及 CNINFO 公告/监管事件分页、步骤审计信息、对应测试、CHANGELOG 和 OpenSpec 文档；不改变 CLI 或数据湖 schema。