### PR TITLE
feat(trading_status): 将派生停牌记录正式接入 staging→compact→commit 提交通道

### DIFF
--- a/configs/cnequity.example.toml
+++ b/configs/cnequity.example.toml
@@ -365,6 +365,7 @@ parallel = true
 steps = [
   "instruments", "trading_calendar", "trading_status",
   "corporate_actions", "daily_bars", "index_bars",
+  "trading_status_derive",
   "compact", "derive_adj_factors", "derive_industry_index",
 ]
 

--- a/openspec/changes/trading-status-suspension-derive-channel/.openspec.yaml
+++ b/openspec/changes/trading-status-suspension-derive-channel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/trading-status-suspension-derive-channel/design.md
+++ b/openspec/changes/trading-status-suspension-derive-channel/design.md
@@ -1,0 +1,91 @@
+## Context
+
+参见 proposal.md（Why）以了解动机。当前事实基线（2026-09-01 实测于 datalake 湖）：
+
+- `trading_status` 是 `snapshot` 语义数据集：daily 步骤经 `fetch_incremental_daily` 只请求 `trade_date`（common.py:436-439），历史缺日仅记录为 `coverage_gap` finding，从不回补 ── 因此"每日抓当日停牌快照"无法覆盖历史停牌。
+- `cne backfill trading_status`（baostock `st_history.py:76 if tradestatus != "1": continue`；tushare 仅在有成交日期产行）**故意跳过停牌日**：只产出 `is_trading=True` 的 normal/ST 行，是 ST 标签回填，不是停牌回填。
+- 能反推停牌的 `derive_suspension_history`（`derive/trading_status_history.py`）现用 `CuratedWriter.write_partition` **直写可变 curated 目录**，全函数无 `revisions.commit()`。产物：(1) committed 读者（`load_curated_trading_status` → `collect_parquet_root(committed=True)` 经 `_resolved_root` 解析）不可见；(2) 下一次 compact 从 committed 快照 + 本次 staging 重建分区（`parquet.py:148,217`），会把可变目录里的手工/derive 行冲掉。
+- 证据分级已存在：`status_evidence_rank`（trading_status_history.py:61-90）rank 0 = baostock / 已收盘 EastMoney 当日快照（fetched 日期==trade_date 且 >=15:00）/ 退市；rank 1 = `derived_bar_gap`；rank 2 = 滞后 EastMoney 当前态盖旧日期。但该分级**只用于 derive 自己的合并**，compact 的通用去重（`domain/canonical.py:28-55`）按 `fetched_at` 升序 + source rank(base=0/primary=2) 排序、`keep="last"` → 恰好更新的普通快照会盖掉 derived 停牌行。
+- 每日 bar 路径已有未收盘防护：`_reject_unfinished_daily_bar_window`（bars.py:51）拒绝 15:00 前抓当日。derive 路径**没有**该防护。
+
+**关于数据集边界与提交粒度的澄清（避免对"是否破坏原有设计"的误读）：**
+
+- `trading_status` 与 `daily_bars` 是**两个独立 dataset，各自走独立的 `staging → compact → commit` 流程、各自生成 revision 提交**——在 `_compact_locked`（finalize.py:345-473）中按 dataset 逐个 `compact_dataset` + `revisions.commit(ds)`。现有代码（derive 缺陷修复前）从不存在"is_trading=false 与 daily bar 同批统一提交"的路径。
+- 二者在 daily 管线中的耦合只在**门禁/校验层**，而非提交合并层：daily_bars 的 interior-gap 校验（`_staged_daily_bar_missing_keys`，bars.py:1029）与所有权分类（`classify_daily_bar_ownership` 的 `trading_status_non_trading` 分支，common.py:819）要求 **已提交的 `is_trading=false` 记录**作为缺失会话的显式豁免证据，daily_bars 批次满足该条件后才允许 checkpoint。
+- 本变更**不改动 dataset 边界、不合并提交、也不做任何"分拆提交"**：只把 derive 的写路径从直写可变目录改为走 trading_status 自身的 staging→compact→commit 通道，使反推停牌行成为 daily_bars 门禁所称的"已提交豁免证据"。daily_bars 的批次门禁语义不变（见 Non-Goal：interior-gap "缺失 ≠ 停牌" 保持）。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 让 `derive_suspension_history` 的反推行通过 `staging → compact → commit` 正式发布，对 committed 读者可见且不被后续 compact 冲掉。
+- 为 derive 补上"当日未收盘拒绝"防护（与 daily_bars 同款），杜绝盘中把"今天没 bar"误判为停牌。
+- 让 compact 合并 trading_status 时**先按 `status_evidence_rank` 再按 `fetched_at`**，保住 derived 停牌行不被"更新的普通快照"覆盖，同时保留权威源修正 derived 的能力。
+- 将反推固化为每日自动环节（挂 daily core group），并保持手动入口（`cne derive trading_status`）行为一致。
+
+**Non-Goals:**
+- 不改 daily_bars 的 interior-gap 校验语义（"缺失 ≠ 停牌"，common.py:816 的保守设计保持不变）。
+- 不把 `derived_bar_gap` 提升为权威证据（保持 rank 1，可被权威源修正）。
+- 不做 EastMoney 历史名单回查（方案 D）——依赖"EastMoney 是否保留很久以前当日名单"这一未验证前提，留作独立后续评估。
+
+## Decisions
+
+### 决策 1：derive 写入改为 staging→compact→commit（方案 A）
+
+`derive_suspension_history` 不再用 `CuratedWriter` 直写可变目录，改为：构造符合 trading_status schema 的 row → `StagingWriter.write_batch(dataset="trading_status", run_id, batch_id, df)` → 由 compact 步骤统一合并发布。
+
+- **理由**：与既有 `step_trading_status`/backfill 的写入路径一致；compact 负责 `dedupe_by_primary_key`、生成修订、原子翻转 `current.json`，保证 committed 读者可见与持久性，天然解决"草稿层不可见 + 被冲掉"两个缺陷。
+- **替代方案（拒绝）**：
+  - "保留直写并在直写后手动调用 `revisions.commit()`"——绕过 compact 的合并/审计门（source_diff gate 等），且与现有发布管线分叉，风险大于收益。拒绝。
+  - "把 `current.json` 手动指向新代"——脆弱、易与并发 compact 竞争。拒绝。
+- **实现形态**：由于 `trading_status` 是月分区，derive 应沿用 `_STATUS_SPEC.partition_for(td)` 生成分区值，写入 staging 后由 compact 按既有月分区合并（`compact_dataset` 已支持 `partition_col="trade_date"` + 月粒度）。staging batch_id 建议 `derived-<迭代序号>`，可复用 backfill 的 `_finish_backfill_run` 路径（若经 CLI）或注册成独立 step 后在 daily run 中被 compact 覆盖。
+- **不影响既有语义**：本决策只改 derive 的写通道，不合并/拆分 trading_status 与 daily_bars 的 dataset 边界或提交粒度（详见 Context 的澄清）：trading_status 仍独立提交，daily_bars 仍按批次在满足门禁后提交。
+
+### 决策 2：compact 合并保留 status_evidence_rank
+
+在 `storage/parquet.py`/`domain/canonical.py` 的 trading_status 合并排序中，把 `status_evidence_rank` 作为主排序键（升序，rank 0 排最后 → `keep="last"` 保留），`fetched_at/source/data_version` 降为次级键。
+
+- **理由**：证据分级是 trading_status 独有且已存在语义；通用 `fetched_at` 去重会令"更新的普通快照"（rank 2）盖掉 derived（rank 1），直接摧毁本次反推的成果。
+- **实现注意**：`status_evidence_rank` 定义在 `derive/trading_status_history.py`（仅写端）；compact 读端不能 import derive 层。需把该函数抽到共享位置（如 `domain/trading_status.py` 或 `query/canonical.py` 专用 hook），供 `compact_dataset` / `dedupe_by_primary_key` 在 `dataset=="trading_status"` 时启用。可用"per-dataset source-rank 注入"机制（类似现有 `_source_rank_expr`），不破坏其他数据集去重。
+- **替代方案（拒绝）**："compact 前在 staging 内部先做 rank 合并"——无法阻止 compact 合并既有 committed 行与 staging 时的跨批次竞争。拒绝。
+- **边界**：`classify_daily_bar_ownership`/`_staged_daily_bar_missing_keys` 的读端消费语义不变（显式 `is_trading=false` 才算豁免）。
+
+### 决策 3：未收盘/当日防护复用 daily_bars 逻辑
+
+derive 对"今天"且 `shanghai_now().time() < _DAILY_BAR_FINAL_AT`（15:00）且 `is_trading_day(config, today)` 的窗口拒绝执行（或排除今天），复用/提取 `_reject_unfinished_daily_bar_window` 的判定函数到共享模块。
+
+- **理由**：与 daily_bars 行为一致，杜绝盘中 `_suspended_pairs` 把"今天还没出 bar"反推成停牌。
+- **替代方案（拒绝）**："只排除 start==end 的当天"——不足以覆盖以今天为 end 的窗口。拒绝。
+- **实现注意**：`_suspended_pairs` 用 `curated_root/"daily_bars"` 反推，已提交 bar 只会在收盘后被发布，因此该防护主要防御"以今天为 end 的手动/定时触发"；历史 end 天然安全。
+
+### 决策 4：注册 derive 步骤并挂 daily core group
+
+新增/注册步骤（如 `register_step("trading_status_derive")`）在 daily run 中于 daily_bars 之后运行（`fetch_incremental_daily` 对 trading_status 是 snapshot 语义，derive 补充的是历史反推，两者互补）；或在 init 的 phase3/daylier compaction 前插入。挂入 `job.daily.groups.core` steps（config 模板），保证 compact 在同批覆盖其 staging。
+
+- **理由**：历史停牌缺口只能靠反推弥补，且每日自动执行才能让"部署前/抓取失败/漏标"窗口的自愈成为常态。
+- **替代方案（拒绝）**："仅在 `cne init` 一次性跑 derive"——仍无法覆盖日常新增缺口。拒绝。
+- **实现注意**：init 的 `DEFAULT_INIT_PHASES`/`INIT_PHASE_STEPS`（orchestrator/init_phases.py）需把 derive 纳入 phase（如 phase3 或新增子阶段），确保初始化时历史停牌也被补齐。
+
+### 决策 5：手动入口保持一致
+
+`cne derive trading_status`（cli/maintain_cmds.py:98）改为走与自动调度相同的 staging→compact→commit 输出（可复用 `_backfill_once` 的 compact 收尾逻辑，或改为触发一个微型 run）。保留 `--start/--end` 只约束反推窗口，不改变防护语义。
+
+## Risks / Trade-offs
+
+- [compact 合并排序改动影响其他数据集] → 仅对 `dataset=="trading_status"` 注入 rank 排序 hook；其余数据集保持原 `fetched_at` 语义，单测覆盖回归。
+- [derive 结果与每日 EastMoney 快照语义竞争（rank 1 vs rank 2）] → 决策 2 保证 rank 1 胜出；若日后权威源（baostock/已收盘快照 rank 0）对同日给出 contradictory 行，仍按设计正确修正 derive。需在 findings/audit 中记录"derived 被权威修正"以便观察。
+- [staging→compact 改动增加一次 compact 覆盖面] → compact 本就以 stated datasets 为输入，新增 derive staging 只是多一个批次；发布频率与 trading_status 每日 compact 一致，无额外修订放大。
+- [EastMoney 历史名单留存未知（方案 D 前提）] → 本次明确不做 D；若未来评估 D，建议先小范围验证历史日期 `fd=` 回查可用性，再决定是否作为权威补充通道。
+- [已漏历史（如 600984 8/11–8/24）需上线后手动触发一次补齐] → 上线后执行一次 `cne derive trading_status --full`（或等效 backfill）补齐存量缺口，此后由 daily 自动维护。
+
+## Migration Plan
+
+1. 抽取 `status_evidence_rank` → 共享模块；在 `compact_dataset`/`dedupe_by_primary_key` 对 trading_status 启用 rank 排序（决策 2）。
+2. 改造 `derive_suspension_history`：写入 staging；提取未收盘防护（决策 1、3）。
+3. 注册 derive 步骤并挂 daily core steps + init 阶段（决策 4）；`cne derive trading_status` 走新通道（决策 5）。
+4. 上线后执行一次存量补齐（`cne derive trading_status --full`），随后 `cne backfill daily_bars --symbols 600984.SH --start 2026-08-11 --end 2026-08-26` 验证 interior-gap 通过并可 checkpoint。
+5. 回滚：还原 storage/parquet.py 排序 hook 与步骤注册即可；既有 committed 数据不受回滚影响（derive 产物已提交）。
+
+## Open Questions
+
+- 是否需要观察/告警指标标记"derived 被权威源修正"（区分正常修正 vs 反推错误率）——可滞后决定，不影响 specs/方案/任务拆分。
+- 未来是否评估方案 D（EastMoney 历史名单回查）作为权威补充——独立立项，不阻塞本次 A。

--- a/openspec/changes/trading-status-suspension-derive-channel/proposal.md
+++ b/openspec/changes/trading-status-suspension-derive-channel/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+`trading_status` 的历史停牌记录存在一个结构性缺口:它既不能被 daily EastMoney 当日快照覆盖(该数据集为 `snapshot` 语义,只抓当天、从不回溯历史),也不能被 `cne backfill trading_status` 覆盖(baostock/tushare 只在 `tradestatus="1"` 的交易日产行,停牌日被 `st_history.py:76 if tradestatus != "1": continue` 显式跳过)。能反推停牌的 `derive_suspension_history` 现在直接写可变 curated 目录而**不调用 `revisions.commit()`**,导致产物永远停留在用户不可见的"草稿层";即使该 derive 命令被手动执行,其输出也既不会被 committed 读者看到,又会在下一次 compact 时被从旧快照重建而冲掉。
+
+实际故障(2026-09-01 观测):`cne backfill daily_bars --symbols 600984.SH --start 2026-08-11 --end 2026-08-26` 报
+`RuntimeError: 10 interior symbol×session key(s) remain absent; refusing to checkpoint`。daily_bars 数据本身是正确的(8/11–8/24 该股停牌、本就没有 bar,8/25、8/26 有成交且已正确入库),但 interior-gap 校验器(`_staged_daily_bar_missing_keys`)要求 `is_trading=false` 的**显式豁免证据**,而已发布的 committed 快照里没有这 10 天的停牌行。本次变更把"从 bar 缺口反推停牌"的机制接到正式提交通道上,并固化为每日自动维护环节。
+
+## What Changes
+
+- **A1. derive 写入接入正式提交通道**:`derive/trading_status_history.py` 的 `derive_suspension_history` 从 `CuratedWriter` 直写可变目录,改为 **staging → compact → commit** 通道(或等效地:通过已注册步骤 + compact 发布新修订),使反推出的停牌行对 committed 读者可见且持久。
+- **A2. 未收盘/当日防护**:为 derive 补上与 daily_bars 相同的"未收盘(15:00 Asia/Shanghai 前)拒绝当日"防护(`_reject_unfinished_daily_bar_window` 同款逻辑),避免盘中把"今天还没出 bar"误判为"今天停牌"。
+- **A3. compact 合并保留证据等级**:compact 阶段对 `trading_status` 的合并排序从"先 `fetched_at` 后 source rank"改为 **先 `status_evidence_rank`(baostock/已收盘快照=0, derived_bar_gap=1, 滞后快照=2)再 `fetched_at`**,避免"更新的普通 EastMoney 快照"意外盖掉 derived 停牌行,同时保留权威源(rank 0)对 derived 的修正能力。
+- **A4. 每日自动调度**:将新的 derive 步骤挂进 `job.daily.groups.core` 的环保 steps(与 daily_bars 同批),实现每日自动补历史停牌缺口;保留手动 `cne derive trading_status` 入口但使其同样走提交通道。
+- **A5. 非目标**:不改 daily_bars 的 interior-gap 校验语义("缺失 ≠ 停牌");不把 derive 反推当作权威事实(`derived_bar_gap` 维持 rank 1,可被权威源修正);不做 EastMoney 历史名单回查(方案 D,需先验证 EastMoney 历史留存,留作后续评估)。
+
+## Capabilities
+
+### New Capabilities
+
+- `trading_status/suspension-history`:定义 `trading_status` 历史停牌(suspension)记录的维护契约——从 daily_bars 交易缺口反推停牌、反推行必须经正式提交通道发布并对 committed 读者可见、未收盘/当日排除防护、证据等级(权威 > derived)在 compact 合并中被保留、每日自动执行补缺口。覆盖:derive 通道改造、compact 合并等级语义、调度挂载、手动入口一致性。
+
+### Modified Capabilities
+
+<!-- 无既有已归档 spec 受影响(openspec/specs 当前为空)。 -->
+
+## Impact
+
+- 修改:
+  - `src/cnequity/derive/trading_status_history.py`(写入通道、证据等级接入、未收盘防护)
+  - `src/cnequity/storage/parquet.py`(`compact_dataset` 对 trading_status 的合并排序保留 `status_evidence_rank`)
+  - `src/cnequity/steps/reference.py` 或 orchestrator/init_phases(注册 derive 步骤 / 挂 daily core wave)
+  - `src/cnequity/cli/maintain_cmds.py`(`cne derive trading_status` 走新通道)
+  - 配置模板(`configs/cnequity.example.toml` daily core steps 增加 derive 步骤)
+  - 单测:derive/compact 合并、未收盘拒绝、提交可见性
+- 不涉及:daily_bars 校验逻辑、manifest schema、duckdb 视图、EastMoney adapter(除非方案 D 评估)。
+- 副作用:每日新增一次 derive 计算(基于已提交 daily_bars 与 trading_calendar 反推),资源开销与现有 `cne derive trading_status` 一致;发布新修订频率与 trading_status 每日 compact 一致。
+- 部署注意:editable 安装即时生效;已漏的历史停牌需在变更上线后跑一次 `cne derive trading_status --full`(或对应 backfill)补齐,此后由 daily 自动维护。

--- a/openspec/changes/trading-status-suspension-derive-channel/specs/trading_status/suspension-history/spec.md
+++ b/openspec/changes/trading-status-suspension-derive-channel/specs/trading_status/suspension-history/spec.md
@@ -1,0 +1,78 @@
+## Purpose
+
+定义了 trading_status 历史停牌(suspension)记录的维护契约:系统从已提交的 daily_bars 交易缺口反推停牌日,反推结果必须通过正式提交通道(staging→compact→commit)发布并对 committed 读者可见,同时保证未收盘当日不被误判、且权威来源(baostock/已收盘 EastMoney)能够修正低等级的 derive 推断。该能力确保历史停牌证据在 daily 当日快照与 ST 回填均无法覆盖的场景下仍可被补齐并持久化。
+
+## ADDED Requirements
+
+### Requirement: 停牌反推必须经正式提交通道发布
+
+系统 SHALL 将 `derive_suspension_history` 产出的 `is_trading=false`(status=suspended)行写入 staging,并经 compact 发布为新的 committed 修订;反推结果 MUST 对 `load_curated_trading_status`(committed 读者)可见,且 MUST 不得被下一次 compact 从旧快照重建所冲掉。
+
+#### Scenario: derive 反推行对 committed 读者可见
+- **WHEN** 执行 `cne derive trading_status --full`(或等效自动调度)反推出某 symbol×date 的停牌行
+- **THEN** 该行经 staging→compact→commit 后,t出现在 committed 修订快照中
+- **AND** `load_curated_trading_status(start=…, end=…, symbols=[…])` 能读到该行的 `is_trading=false`
+
+#### Scenario: 后续 compact 不冲掉反推停牌行
+- **WHEN** derive 发布后,后续任一 trading_status compact 再次运行
+- **THEN** 已提交的 derived 停牌行仍保留在最新 committed 快照中
+- **AND** 不因"可变目录被从旧快照重建"而丢失
+
+### Requirement: 当日未收盘不得被反推为停牌
+
+derive 反推 SHALL 对"今天"且当前上海时间早于 15:00:00 的会话拒绝生成 `is_trading=false` 行(复用 daily_bars 的 `_reject_unfinished_daily_bar_window` 语义),避免把"当日 bar 尚未产生"误判为"当日停牌"。历史日期与非交易日不受此限制。
+
+#### Scenario: 盘中止于当日 derive
+- **WHEN** 在上海时间 15:00 前对以今天为 `end` 的窗口执行 derive
+- **THEN** 今天不被写入任何派生停牌行
+- **AND** 该次 derive 以错误/拒绝结束,提示会话未收盘
+
+#### Scenario: 收盘后或历史日期 derive 正常
+- **WHEN** 上海时间 >= 15:00 后,或 `end` 早于今天的窗口执行 derive
+- **THEN** 正常反推并发布停牌行,不受当日防护拦截
+
+### Requirement: compact 合并保留停牌证据等级
+
+compact 合并 trading_status 时 SHALL 先按数据来源证据等级排序,再按 `fetched_at` 排序;等级越高者优先保留(baostock / 已收盘的 EastMoney 当日快照 / 退市 = rank 0,`derived_bar_gap` 推断 = rank 1,滞后的 EastMoney 当前态快照盖到旧日期 = rank 2)。此规则 MUST 防止"恰好更新的普通 EastMoney 快照"覆盖 rank 1 的 derived 停牌行,同时保留权威源对 derived 推断的修正能力。
+
+#### Scenario: 更新的普通快照不得覆盖 derived 停牌
+- **WHEN** 同一 symbol×date 同时存在 `derived_bar_gap`(is_trading=false) 与一张 `fetched_at` 更新的普通 EastMoney 快照行
+- **THEN** compact 合并后保留 `derived_bar_gap`(rank 1 > rank 2)的 `is_trading=false`
+- **AND** 普通快照不因 `fetched_at` 更晚而胜出
+
+#### Scenario: 权威源可修正 derived 停牌
+- **WHEN** 同一 symbol×date 同时存在 `derived_bar_gap`(rank 1) 与 baostock 或已收盘的 EastMoney 当日快照(rank 0)
+- **THEN** compact 合并后保留 rank 0 权威行的状态
+- **AND** 若权威行证明该日交易(rank 0, is_trading=true),derived 的 is_trading=false 被修正为正常
+
+### Requirement: 每日自动补齐历史停牌缺口
+
+系统 SHALL 提供一个注册步骤,将停牌反推纳入每日作业;该步骤 SHALL 与 daily_bars 同批(daily core group)执行,自动对已提交的 daily_bars / trading_calendar 反推并发布停牌行,使历史停牌缺口(daily 快照漏标、抓取失败、部署前窗口)得以每日自动补齐。手动 `cne derive trading_status` 入口 MUST 保持可用且同样走提交通道。
+
+#### Scenario: 每日作业自动补齐缺口
+- **WHEN** 每日 trading_status 维护(daily core)运行
+- **THEN** 系统基于已提交 daily_bars 反推缺失的停牌日
+- **AND** 结果经提交通道发布,无需人工介入
+
+#### Scenario: 手动 derive 与自动调度行为一致
+- **WHEN** 操作者手动运行 `cne derive trading_status --start/--end`
+- **THEN** 产出的停牌行路径与自动调度相同(staging→compact→commit)
+- **AND** 均受未收盘当日防护约束
+
+### Requirement: 反推证据等级维持为推断而非权威
+
+derive 产出的停牌行 SHALL 保持 `source=derived_bar_gap` 与 rank 1 语义,不得被提升为权威证据;系统 MUST 允许未来出现的权威证据(baostock 历史 / 已收盘当日快照 / 退市)按等级修正或覆盖这些推断行,以实现"列为疑似、等待权威确认"的设计意图。
+
+#### Scenario: derived 行不覆盖权威证据
+- **WHEN** derive 反推行与权威行在 compact 中竞争同一 symbol×date
+- **THEN** 权威行(rank 0)胜出,derived 行(rank 1)被覆盖或修正
+- **AND** derived 行本身从不作为最高权威因 `is_trading=false` 豁免而越过权威源
+
+### Requirement: 反推缺口窗口边界
+
+derive 反推 SHALL 将 symbol×date 的期望范围限定为该 symbol 的上市/退市活动区间(list_date..delist_date 与 bar 区间交集)内,且仅与 `is_trading=true` 的交易日历会话交叉;超出活动区间的日期 MUST NOT 被推定为停牌。
+
+#### Scenario: 上市前/退市后日期不被反推
+- **WHEN** derive 反推包含某 symbol 的 list_date 之前或 delist_date 之后的日期
+- **THEN** 这些日期不出现在输出的停牌行中
+- **AND** 只有活动区间内的无 bar 交易日被反推

--- a/openspec/changes/trading-status-suspension-derive-channel/tasks.md
+++ b/openspec/changes/trading-status-suspension-derive-channel/tasks.md
@@ -1,0 +1,30 @@
+## 1. 提取共享证据等级与防护工具
+
+- [x] 1.1 将 `status_evidence_rank`（现位于 `derive/trading_status_history.py:61-90`）抽取到共享模块（如 `domain/trading_status.py`），保持 rank 语义不变（baostock/已收盘快照/退市=0, derived_bar_gap=1, 滞后快照=2）；验证 `derive/trading_status_history.py` 改 import 后既有单测通过
+- [x] 1.2 将 `_reject_unfinished_daily_bar_window` 的当日判定逻辑（15:00 最新，`is_trading_day` 判定）提取到共享函数（如 `steps/common.py` 或 `domain/calendar.py`），导出 `_DAILY_BAR_FINAL_AT` 常量；验证 daily_bars 调用方仍通过原有测试
+
+## 2. compact 合并保留证据等级
+
+- [x] 2.1 在 `domain/canonical.py`（`_source_rank_expr`/`_sort_for_canonical`）为 `dataset=="trading_status"` 注入 `status_evidence_rank` 主排序键（rank 0 排最后, `keep="last"` 保留胜利行）, `fetched_at/source/data_version` 降为次级键; 验证新增单测"更新的普通 EastMoney 快照(rank 2) 不覆盖 derived_bar_gap(rank 1)"通过
+- [x] 2.2 验证权威行(rank 0: baostock/已收盘快照)在 compact 合并中胜出并修正 derived 停牌行, 新增单测"权威源修正 derived"通过
+- [x] 2.3 验证非 trading_status 数据集去重语义不变（按 fetched_at + source rank）, 既有 compact 单测全部通过（回归）
+
+## 3. derive 写入接入正式提交通道
+
+- [x] 3.1 改造 `derive_suspension_history`: 不再直写可变目录, 改用 `StagingWriter.write_batch(dataset="trading_status", run_id, batch_id=<derived-序号>, df)` 写入 staging（月分区 via `_STATUS_SPEC.partition_for`）; 验证单测"反推行进入 staging 且 schema 正确"
+- [x] 3.2 确保 derive 的 staging 能被既有 `compact_dataset` 按月分区合并（dedupe by PK + 决策 2 的 rank 排序）并发布为 committed 修订; 验证"derive 后 compact → `load_curated_trading_status`(committed=True) 可见 `is_trading=false` 行" 集成测试通过
+- [x] 3.3 验证"后续再次 compact 不冲掉 derived 停牌行": 连续两次 compact 后 derived 行仍在最新 committed 快照（单测/集成测试）
+- [x] 3.4 为 derive 接入未收盘防护（决策 3）: 上海时间 <15:00 且 `end==today` 且为交易日时拒绝执行并报错; 新增单测"盘中止于当日 derive"与"收盘后/历史日期正常"通过
+
+## 4. 注册步骤、调度挂载与手动入口
+
+- [x] 4.1 注册 derive 步骤（如 `register_step("trading_status_derive")` 于 `steps/reference.py` 或独立模块）, 复用 `derive_suspension_history` 并以窗口参数运行; 验证 `validate_steps_registered` 通过
+- [x] 4.2 将新步骤挂入 daily core group（`config/templates/cnequity.example.toml` 的 `[job.daily.groups.core]` steps, 置于 daily_bars 之后/compact 之前）; 验证配置模板可被 `cne config init`/校验加载
+- [x] 4.3 将 derive 纳入 init 阶段（`orchestrator/init_phases.py` 的 `INIT_PHASE_STEPS`, 如 phase3 或新子阶段）, 保证初始化补齐历史停牌; 验证 `expected_steps`/`pending_phases` 相关单测通过
+- [x] 4.4 `cli/maintain_cmds.py` 的 `cne derive trading_status` 改走新通道（staging→compact→commit, 可复用 `_backfill_once` 收尾）; 验证 CLI 集成测试或手动运行产出 committed 可见行
+
+## 5. 存量数据补齐与端到端验证
+
+- [x] 5.1 变更上线后执行一次存量补齐（`cne derive trading_status --full` 或等效）, 验证 600984.SH 8/11–8/24 生成 `is_trading=false` 行且经提交通道可见
+- [x] 5.2 重跑 `cne backfill daily_bars --symbols 600984.SH --start 2026-08-11 --end 2026-08-26`, 验证不再报 "10 interior symbol×session key(s) remain absent" 且可正常 checkpoint
+- [x] 5.3 运行 `cne audit trading_status` / `cne audit daily_bars` 相关校验, 确认无新的覆盖/缺口 findings

--- a/src/cnequity/cli/maintain_cmds.py
+++ b/src/cnequity/cli/maintain_cmds.py
@@ -95,9 +95,35 @@ def derive(name: str, config_path: str, full: bool, start_str: str | None, end_s
         summary = derive_industry_index(cfg, start=start, end=end, full=full)
         click.echo(json.dumps(summary, indent=2, default=str))
     elif name == "trading_status":
+        from datetime import timedelta
+
         from cnequity.derive.trading_status_history import derive_suspension_history
 
-        rows = derive_suspension_history(cfg, start=start, end=end)
+        # The current session's bar is only published by its own compact, so a
+        # manual derive defaults to the previous day and must not turn the
+        # current day's still-uncommitted bar into a suspension. An explicit
+        # ``--end today`` is allowed only once the session is finalized (the
+        # derive path applies the same unfinished-session guard as daily_bars).
+        trade_date = shanghai_today()
+        end = end or trade_date - timedelta(days=1)
+        engine = JobEngine(cfg)
+        run_id = engine.manifest.start_run(
+            "derive",
+            {"trade_date": trade_date.isoformat(), "target": "trading_status"},
+        )
+        try:
+            rows = derive_suspension_history(cfg, start=start, end=end, run_id=run_id)
+            if rows:
+                engine.run_step("compact", trade_date, run_id)
+            engine.manifest.finish_run(
+                run_id,
+                "success",
+                rows_read=rows,
+                rows_written=rows,
+            )
+        except Exception as exc:
+            engine.manifest.finish_run(run_id, "failed", error_message=str(exc))
+            raise
         click.echo(f"Derived historical suspension: {rows} rows into trading_status")
     elif name == "sector_routing":
         from cnequity.derive.sector_routing import derive_sector_routing

--- a/src/cnequity/config/templates/cnequity.example.toml
+++ b/src/cnequity/config/templates/cnequity.example.toml
@@ -365,6 +365,7 @@ parallel = true
 steps = [
   "instruments", "trading_calendar", "trading_status",
   "corporate_actions", "daily_bars", "index_bars",
+  "trading_status_derive",
   "compact", "derive_adj_factors", "derive_industry_index",
 ]
 

--- a/src/cnequity/derive/trading_status_history.py
+++ b/src/cnequity/derive/trading_status_history.py
@@ -7,8 +7,11 @@ suspended day, however; those rows carry ``volume=0``. A listed symbol with no
 and covers the whole bar history — filling the trading_status gap that free ST
 feeds (EastMoney's current-snapshot ST board) cannot reach.
 
-Only sparse ``suspended`` rows are written; real daily rows (EastMoney) win on
-any primary-key overlap.
+The derived rows are only provisional suspension evidence
+(``source=derived_bar_gap``, rank 1). They are staged into the
+``trading_status`` dataset and published by compact (`staging → compact →
+commit`) so committed readers see them and a later authority (rank 0) can
+correct them.
 
 Optional ``start`` / ``end`` bound the calendar cross-join so a 2001→today
 rebuild can run year-by-year without OOM.
@@ -17,77 +20,22 @@ rebuild can run year-by-year without OOM.
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
-from datetime import date, datetime, time
-from typing import Any
-from zoneinfo import ZoneInfo
+from datetime import date, datetime
 
 import polars as pl
 
 from cnequity.config import Config
-from cnequity.domain.datasets import DATASETS
 from cnequity.domain.schemas import validate_dataframe, with_provenance
 from cnequity.domain.trading_status import (
-    DELISTED_SOURCE,
+    DERIVED_BAR_GAP_SOURCE,
     STATUS_SUSPENDED,
-    normalize_legacy,
 )
 from cnequity.query.canonical import dedupe_by_primary_key, dedupe_lazy_by_primary_key
 from cnequity.query.parquet_scan import dataset_has_parquet, scan_parquet_root
-from cnequity.storage.parquet import CuratedWriter
+from cnequity.steps.common import reject_unfinished_eod_window
+from cnequity.storage import StagingWriter
 
 logger = logging.getLogger(__name__)
-
-_DERIVED_SOURCE = "derived_bar_gap"
-_STATUS_SPEC = DATASETS["trading_status"]
-_CURRENT_SNAPSHOT_SOURCES = frozenset({"eastmoney", "tdx_protocol"})
-_SHANGHAI = ZoneInfo("Asia/Shanghai")
-_SESSION_FINAL = time(15, 0)
-
-
-def _as_shanghai_datetime(value: Any) -> datetime | None:
-    if isinstance(value, str):
-        try:
-            value = datetime.fromisoformat(value.replace("Z", "+00:00"))
-        except ValueError:
-            return None
-    if not isinstance(value, datetime):
-        return None
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=ZoneInfo("UTC"))
-    return value.astimezone(_SHANGHAI)
-
-
-def status_evidence_rank(row: Mapping[str, Any]) -> int:
-    """Precedence for a collision with a derived bar-gap suspension.
-
-    Historical Baostock evidence and a finalized same-session EastMoney
-    snapshot are point-in-time facts. A later current-state snapshot stamped
-    onto an older date is not. Unknown sources win conservatively so a newly
-    introduced authority is never overwritten without an explicit policy.
-    """
-    source = str(row.get("source") or "")
-    if source == "baostock":
-        return 0
-    if source in _CURRENT_SNAPSHOT_SOURCES:
-        fetched = _as_shanghai_datetime(row.get("fetched_at"))
-        trade_date = row.get("trade_date")
-        if (
-            fetched is not None
-            and isinstance(trade_date, date)
-            and fetched.date() == trade_date
-            and fetched.time() >= _SESSION_FINAL
-        ):
-            return 0
-        return 2
-    if source == DELISTED_SOURCE:
-        # A formal delisting is a fact about the security, not an observation
-        # of one session, so it outranks a current-state snapshot that simply
-        # never learned the name is gone.
-        return 0
-    if source == _DERIVED_SOURCE:
-        return 1
-    return 0
 
 
 def _suspended_pairs(
@@ -196,12 +144,29 @@ def derive_suspension_history(
     *,
     start: date | None = None,
     end: date | None = None,
+    run_id: str = "derive",
+    batch_id: str | None = None,
+    now: datetime | None = None,
 ) -> int:
-    """Write derived ``suspended`` rows into curated trading_status. Returns row count.
+    """Stage derived ``suspended`` rows into trading_status. Returns row count.
 
-    When *start* / *end* are set, only that calendar window is considered — use
-    yearly chunks for a full-history rebuild to keep the cross-join bounded.
+    Rows are written through :class:`StagingWriter` into the ``trading_status``
+    dataset under *run_id*; compact (in the same run) merges them by evidence
+    rank and publishes a committed revision. Compact is responsible for
+    partitioning by the month, deduplicating against existing authored rows,
+    and keeping the derived row only when no authority contradicts it.
+
+    When *start* / *end* are set, only that calendar window is considered —
+    use yearly chunks for a full-history rebuild to keep the cross-join
+    bounded. Callers that schedule the derive against the current session
+    (``end == today``) must run it only once that session's bar is finalized;
+    the same unfinished-session guard as daily_bars applies here, and a daily
+    run should pass ``end`` strictly before the session whose bar is only
+    staged (not yet committed) in the same run. ``now`` is injectable for a
+    deterministic timezone boundary in tests.
     """
+    if end is not None:
+        reject_unfinished_eod_window(config, end, what="trading_status", now=now)
     pairs = _suspended_pairs(config, start=start, end=end)
     if pairs.is_empty():
         return 0
@@ -214,69 +179,17 @@ def derive_suspension_history(
         # `st_coverage` is what tracks where ST evidence is actually absent.
         pl.lit(None, dtype=pl.Boolean).alias("risk_warning"),
     )
-    rows = with_provenance(rows, source=_DERIVED_SOURCE, data_version="v1")
+    rows = with_provenance(rows, source=DERIVED_BAR_GAP_SOURCE, data_version="v1")
     rows = validate_dataframe(rows, "trading_status")
-
-    # trading_status is month-partitioned — never write day dirs that fight the
-    # registry (audit: mixed_partition_granularity) and republish PKs.
-    writer = CuratedWriter(config.curated_root)
-    pcol = _STATUS_SPEC.partition_col or "trade_date"
-    part_vals = [
-        _STATUS_SPEC.partition_for(td) if isinstance(td, date) else str(td)
-        for td in rows["trade_date"].to_list()
-    ]
-    rows = rows.with_columns(pl.Series("_part", part_vals))
-    total = 0
-    for key, group in rows.partition_by("_part", as_dict=True).items():
-        val = str(key[0] if isinstance(key, tuple) else key)
-        group = group.drop("_part")
-        existing_dir = writer.partition_path("trading_status", pcol, val)
-        frames = [group]
-        stray_parts: list = []
-        if existing_dir.exists():
-            for f in existing_dir.rglob("*.parquet"):
-                # Existing partitions may predate the status/risk_warning
-                # split; normalize before validating so an old lake is
-                # migrated by the rewrite instead of failing the derive.
-                frames.append(
-                    validate_dataframe(normalize_legacy(pl.read_parquet(f)), "trading_status")
-                )
-                if f.name != "part-merged.parquet":
-                    stray_parts.append(f)
-        merged = pl.concat(frames, how="diagonal_relaxed")
-        if "fetched_at" not in merged.columns:
-            merged = merged.with_columns(pl.lit(None, dtype=pl.Datetime("us")).alias("fetched_at"))
-        merged = merged.with_columns(
-            pl.struct(["source", "trade_date", "fetched_at"])
-            .map_elements(status_evidence_rank, return_dtype=pl.Int64)
-            .alias("_evidence_rank")
-        )
-        # Keep the best evidence, but make ties independent of filesystem
-        # traversal order.  Within one evidence class the newest observation
-        # wins; source and version then provide a stable final tie-breaker.
-        # Null provenance is sorted first so a known timestamp is retained by
-        # ``keep="last"`` instead of a legacy row silently winning.
-        sort_cols = ["_evidence_rank"]
-        descending = [True]
-        for column in ("fetched_at", "source", "data_version"):
-            if column in merged.columns:
-                sort_cols.append(column)
-                descending.append(False)
-        merged = (
-            merged.sort(
-                sort_cols,
-                descending=descending,
-                nulls_last=False,
-                maintain_order=True,
-            )
-            .unique(subset=["symbol", "trade_date"], keep="last")
-            .drop("_evidence_rank")
-        )
-        # Reuse compact's filename so we overwrite the single canonical part
-        # rather than adding a second file (which would double-count on read).
-        writer.write_partition("trading_status", pcol, val, merged, "part-merged.parquet")
-        for stray in stray_parts:
-            stray.unlink(missing_ok=True)
-        total += group.height
-    logger.info("derived %d historical suspension rows into trading_status", total)
-    return total
+    StagingWriter(config.staging_root).write_batch(
+        "trading_status",
+        run_id,
+        batch_id or "derived-suspension",
+        rows,
+    )
+    logger.info(
+        "derived %d historical suspension rows into trading_status staging for run %s",
+        rows.height,
+        run_id,
+    )
+    return rows.height

--- a/src/cnequity/domain/canonical.py
+++ b/src/cnequity/domain/canonical.py
@@ -6,6 +6,7 @@ import polars as pl
 
 from cnequity.domain.datasets import DATASETS
 from cnequity.domain.schemas import PRIMARY_KEYS
+from cnequity.domain.trading_status import evidence_rank_expr
 
 _SOURCE_RANK = "__canonical_source_rank"
 
@@ -26,24 +27,48 @@ def _source_rank_expr(dataset: str, columns: set[str]) -> pl.Expr | None:
 
 
 def _sort_for_canonical(frame, dataset: str):
-    """Order freshest rows, then source priority, before PK collapse."""
-    columns = (
-        set(frame.collect_schema().names())
-        if isinstance(frame, pl.LazyFrame)
-        else set(frame.columns)
-    )
+    """Order rows before PK collapse so ``keep="last"`` picks the intended row.
+
+    Most datasets prefer the freshest observation, then source priority.
+    ``trading_status`` instead keys on :func:`status_evidence_rank`: rank 0
+    (authority) is sorted last so it survives collision with a derived
+    bar-gap suspension, and a newer ordinary current-state snapshot (rank 2)
+    can never overwrite it. Within one evidence class the newest observation
+    still wins.
+    """
+    schema = frame.collect_schema()
+    columns = set(schema.names())
     sort_cols: list[str] = []
     descending: list[bool] = []
-    if "fetched_at" in columns:
+
+    if (
+        dataset == "trading_status"
+        and "source" in columns
+        and "fetched_at" in columns
+        and isinstance(schema.get("fetched_at"), pl.Datetime)
+    ):
+        fetched_dtype = schema.get("fetched_at")
+        fetched_timezone = getattr(fetched_dtype, "time_zone", None)
+        frame = frame.with_columns(evidence_rank_expr(fetched_timezone).alias(_SOURCE_RANK))
+        sort_cols.append(_SOURCE_RANK)
+        # Lower rank is more authoritative; descending puts rank 0 last so
+        # ``unique(..., keep="last")`` keeps the authority over a derived row.
+        descending.append(True)
         sort_cols.append("fetched_at")
         descending.append(False)
-    rank = _source_rank_expr(dataset, columns)
-    if rank is not None:
-        frame = frame.with_columns(rank.alias(_SOURCE_RANK))
-        sort_cols.extend([_SOURCE_RANK, "source"])
-        # ``unique(..., keep="last")`` selects the last row after sorting.
-        # Primary therefore needs the greatest rank at the end of the sort.
-        descending.extend([False, False])
+        sort_cols.append("source")
+        descending.append(False)
+    else:
+        if "fetched_at" in columns:
+            sort_cols.append("fetched_at")
+            descending.append(False)
+        rank = _source_rank_expr(dataset, columns)
+        if rank is not None:
+            frame = frame.with_columns(rank.alias(_SOURCE_RANK))
+            sort_cols.extend([_SOURCE_RANK, "source"])
+            # ``unique(..., keep="last")`` selects the last row after sorting.
+            # Primary therefore needs the greatest rank at the end of the sort.
+            descending.extend([False, False])
     if "data_version" in columns:
         sort_cols.append("data_version")
         descending.append(False)

--- a/src/cnequity/domain/trading_status.py
+++ b/src/cnequity/domain/trading_status.py
@@ -41,7 +41,10 @@ runs; the migration only makes the old rows say it in the new column.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
+from datetime import date, datetime, time
+from typing import Any
+from zoneinfo import ZoneInfo
 
 import polars as pl
 
@@ -63,6 +66,24 @@ LEGACY_ST_STATUSES = frozenset({"st", "*st"})
 #: from a vendor board: a delisted security appears on no daily board, so no
 #: snapshot can say it stopped trading.
 DELISTED_SOURCE = "derived_delisted"
+
+#: Provenance for suspension rows reconstructed from a missing daily-bar
+#: session. The daily feeds (EastMoney current snapshot, ST backfill) cannot
+#: assert a symbol was halted, so the bar gap is the only evidence and it is
+#: explicitly provisional: ``status_evidence_rank`` keeps it below a finalized
+#: authority so a genuine source can correct it later.
+DERIVED_BAR_GAP_SOURCE = "derived_bar_gap"
+
+#: Sources whose snapshots are current-state observations. A snapshot fetched
+#: on the same session after the 15:00 closing auction is point-in-time fact;
+#: the same current-state answer stamped onto an older date is not.
+_CURRENT_SNAPSHOT_SOURCES = frozenset({"eastmoney", "tdx_protocol"})
+
+#: A snapshot fetched on ``trade_date`` at or after this time (Asia/Shanghai)
+#: is treated as same-session evidence instead of a late current-state guess.
+_SESSION_FINAL = time(15, 0)
+
+_SHANGHAI = ZoneInfo("Asia/Shanghai")
 
 
 def risk_warning_expr(columns: Iterable[str]) -> pl.Expr:
@@ -113,3 +134,87 @@ def is_risk_warning(status: str | None, risk_warning: bool | None = None) -> boo
     if risk_warning:
         return True
     return str(status or "").strip().lower() in LEGACY_ST_STATUSES
+
+
+def _as_shanghai_datetime(value: Any) -> datetime | None:
+    """Normalize a provenance timestamp to an aware Asia/Shanghai datetime.
+
+    Accepts ISO strings, naive datetimes (assumed UTC, matching stored
+    ``fetched_at``), and aware datetimes.
+    """
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=ZoneInfo("UTC"))
+    return value.astimezone(_SHANGHAI)
+
+
+def status_evidence_rank(row: Mapping[str, Any]) -> int:
+    """Precedence for a collision with a derived bar-gap suspension.
+
+    Historical Baostock evidence and a finalized same-session EastMoney
+    snapshot are point-in-time facts. A later current-state snapshot stamped
+    onto an older date is not. Unknown sources win conservatively so a newly
+    introduced authority is never overwritten without an explicit policy.
+
+    Lower rank wins (kept by ``keep="last"`` after an ascending sort); rank 0
+    is the authority that may correct a derived row.
+    """
+    source = str(row.get("source") or "")
+    if source == "baostock":
+        return 0
+    if source in _CURRENT_SNAPSHOT_SOURCES:
+        fetched = _as_shanghai_datetime(row.get("fetched_at"))
+        trade_date = row.get("trade_date")
+        if (
+            fetched is not None
+            and isinstance(trade_date, date)
+            and fetched.date() == trade_date
+            and fetched.time() >= _SESSION_FINAL
+        ):
+            return 0
+        return 2
+    if source == DELISTED_SOURCE:
+        # A formal delisting is a fact about the security, not an observation
+        # of one session, so it outranks a current-state snapshot that simply
+        # never learned the name is gone.
+        return 0
+    if source == DERIVED_BAR_GAP_SOURCE:
+        return 1
+    return 0
+
+
+def evidence_rank_expr(fetched_at_timezone: str | None) -> pl.Expr:
+    """Polars expression reproducing :func:`status_evidence_rank` row-wise.
+
+    ``fetched_at_timezone`` is the stored column's time zone — ``None`` for a
+    naive legacy timestamp, which is treated as UTC (``fetched_at`` is written
+    timezone-aware elsewhere). Kept next to the row function so compact's
+    columnar merge cannot drift from the derive writer's row-wise decision.
+    """
+    fetched = pl.col("fetched_at")
+    if fetched_at_timezone:
+        fetched = fetched.dt.convert_time_zone("Asia/Shanghai")
+    else:
+        fetched = fetched.dt.replace_time_zone("UTC").dt.convert_time_zone("Asia/Shanghai")
+    same_session = (
+        pl.col("trade_date").is_not_null()
+        & (fetched.dt.date() == pl.col("trade_date"))
+        & (fetched.dt.time() >= _SESSION_FINAL)
+    )
+    return (
+        pl.when(pl.col("source") == "baostock")
+        .then(pl.lit(0))
+        .when(pl.col("source").is_in(list(_CURRENT_SNAPSHOT_SOURCES)))
+        .then(pl.when(same_session).then(pl.lit(0)).otherwise(pl.lit(2)))
+        .when(pl.col("source") == DELISTED_SOURCE)
+        .then(pl.lit(0))
+        .when(pl.col("source") == DERIVED_BAR_GAP_SOURCE)
+        .then(pl.lit(1))
+        .otherwise(pl.lit(0))
+    )

--- a/src/cnequity/orchestrator/init_phases.py
+++ b/src/cnequity/orchestrator/init_phases.py
@@ -11,6 +11,10 @@ INIT_PHASE_STEPS: dict[str, list[str]] = {
     "phase2c_daily_bars_backfill": ["daily_bars"],
     "phase3_index_and_status": ["index_bars", "trading_status"],
     "phase4_finalize": ["compact", "derive_adj_factors", "derive_industry_index", "audit"],
+    # Runs after phase4's compact has committed the (backfilled) daily_bars,
+    # so the derive scan sees the complete bar history; its own compact then
+    # publishes the derived suspension rows.
+    "phase5_derive_and_publish": ["trading_status_derive", "compact"],
 }
 
 INIT_BACKFILL_PHASES = frozenset(
@@ -24,6 +28,9 @@ INIT_BACKFILL_PHASES = frozenset(
         # index_bars needs the same 2016+ history as daily_bars for market/beta
         # factors. trading_status ignores backfill (single-day snapshot fetch).
         "phase3_index_and_status",
+        # The derive step must cover the full history on a fresh lake, so it is
+        # run under backfill semantics (full _backfill_start window).
+        "phase5_derive_and_publish",
     }
 )
 
@@ -36,6 +43,7 @@ DEFAULT_INIT_PHASES = [
     "phase2c_daily_bars_backfill",
     "phase3_index_and_status",
     "phase4_finalize",
+    "phase5_derive_and_publish",
 ]
 
 
@@ -64,6 +72,8 @@ def step_backfill(step: str, phases: list[str]) -> bool:
         return "phase1_reference" in phases
     if step in ("index_bars", "trading_status"):
         return "phase3_index_and_status" in phases
+    if step == "trading_status_derive":
+        return "phase5_derive_and_publish" in phases
     return False
 
 

--- a/src/cnequity/steps/bars.py
+++ b/src/cnequity/steps/bars.py
@@ -17,7 +17,7 @@ from cnequity.adapters.tdx_protocol.client import (
 )
 from cnequity.config import Config
 from cnequity.domain.frames import with_columns_unless_blank
-from cnequity.domain.market_time import A_SHARE_FINAL_AT, shanghai_now
+from cnequity.domain.market_time import A_SHARE_FINAL_AT
 from cnequity.domain.rate_limit import source_request
 from cnequity.domain.symbols import split_by_quote_source
 from cnequity.orchestrator.registry import register_step
@@ -29,7 +29,6 @@ from cnequity.steps.common import (
     classify_daily_bar_ownership,
     incremental_window,
     instrument_metadata,
-    is_trading_day,
     list_trading_dates,
     load_bar_universe,
     load_curated_instruments,
@@ -37,6 +36,7 @@ from cnequity.steps.common import (
     load_negative_evidence,
     load_symbols,
     record_negative_evidence,
+    reject_unfinished_eod_window,
 )
 
 logger = logging.getLogger(__name__)
@@ -56,27 +56,15 @@ def _reject_unfinished_daily_bar_window(
 ) -> None:
     """Reject a window whose newest daily bar is still forming in Shanghai.
 
-    TDX ``start=0`` includes the current daily K. Once trading begins that row
-    has plausible OHLC and non-zero volume, so content checks cannot distinguish
-    it from a settled bar. Refuse the fetch before any symbol batch starts: a
-    market-wide sweep that crosses 15:00 would otherwise mix partial and final
-    bars in one curated partition.
-
-    Historical windows and non-trading days are unaffected. ``now`` is
-    injectable so the timezone boundary is deterministic in tests.
+    Thin wrapper over :func:`cnequity.steps.common.reject_unfinished_eod_window`
+    preserving the daily_bars message label. TDX ``start=0`` includes the
+    current daily K: once trading begins that row has plausible OHLC and
+    non-zero volume, so content checks cannot distinguish it from a settled
+    bar. Refuse the fetch before any symbol batch starts so a market-wide
+    sweep that crosses 15:05 never mixes partial and final bars in one
+    curated partition.
     """
-    local_now = shanghai_now(now)
-    today = local_now.date()
-    if end < today or local_now.time() >= _DAILY_BAR_FINAL_AT:
-        return
-    if not is_trading_day(config, today):
-        return
-    raise RuntimeError(
-        f"daily_bars {end}: the current A-share session is not final until "
-        f"{_DAILY_BAR_FINAL_AT.strftime('%H:%M')} Asia/Shanghai "
-        f"(now {local_now.strftime('%H:%M:%S')}); refusing to stage an "
-        "in-progress daily bar. Re-run after the cutoff."
-    )
+    reject_unfinished_eod_window(config, end, what="daily_bars", now=now)
 
 
 def _backfill_window(config: Config, trade_date: date) -> tuple[date, date]:

--- a/src/cnequity/steps/common.py
+++ b/src/cnequity/steps/common.py
@@ -16,6 +16,7 @@ from cnequity.adapters.tdx_protocol.client import fetch_instruments
 from cnequity.config import Config
 from cnequity.domain.datasets import DATASETS, fetch_semantics
 from cnequity.domain.frames import with_columns_unless_blank
+from cnequity.domain.market_time import A_SHARE_FINAL_AT, shanghai_now
 from cnequity.domain.schemas import data_version_for, with_provenance
 from cnequity.domain.symbols import is_subscription_placeholder
 from cnequity.storage import StagingWriter
@@ -25,6 +26,39 @@ logger = logging.getLogger(__name__)
 
 INCREMENTAL_LOOKBACK_DAYS = 5
 BACKFILL_START = date(2016, 1, 1)
+
+
+def reject_unfinished_eod_window(
+    config: Config,
+    end: date,
+    *,
+    what: str = "daily data",
+    now: datetime | None = None,
+) -> None:
+    """Reject an ``end`` session whose daily observation is still forming.
+
+    TDX-style current-day K rows have plausible OHLC and non-zero volume once
+    trading begins, so content checks cannot tell a settled session from a
+    forming one. Refuse before any work starts: a market-wide sweep that
+    crosses the settlement buffer would otherwise mix partial and final
+    observations in one curated partition.
+
+    Historical windows and non-trading days are unaffected. ``now`` is
+    injectable so the timezone boundary is deterministic in tests.
+    """
+    local_now = shanghai_now(now)
+    today = local_now.date()
+    if end < today or local_now.time() >= A_SHARE_FINAL_AT:
+        return
+    if not is_trading_day(config, today):
+        return
+    raise RuntimeError(
+        f"{what} {end}: the current A-share session is not final until "
+        f"{A_SHARE_FINAL_AT.strftime('%H:%M')} Asia/Shanghai "
+        f"(now {local_now.strftime('%H:%M:%S')}); refusing to stage an "
+        "in-progress observation. Re-run after the cutoff."
+    )
+
 
 # These feeds are rolling *calendar*-date disclosures.  A weekend or exchange
 # holiday can still contain a publication, so using ``list_trading_dates``

--- a/src/cnequity/steps/reference.py
+++ b/src/cnequity/steps/reference.py
@@ -536,6 +536,54 @@ def step_trading_status(config: Config, trade_date: date, run_id: str, context: 
     return result
 
 
+# Suspension backfill from bar gaps runs daily; a bounded trailing window
+# keeps the calendar cross-join cheap while still covering missed captions and
+# newly disclosed gaps. Deep history backfills are done through the CLI/init.
+_DAILY_DERIVE_LOOKBACK_DAYS = 30
+
+
+def _trading_status_derive_scope(config: Config, trade_date: date) -> tuple[date | None, date]:
+    """(start, end) window the derive step should scan.
+
+    A daily run must never include the *current* session: its bar is only
+    staged (compact publishes it later in this same run), so a derive reading
+    committed bars would misreport it as a suspension. End at the previous
+    calendar day and bound the scan to a trailing window. Backfill/init runs
+    follow the configured history window instead.
+    """
+    if getattr(config, "_backfill", False):
+        start = getattr(config, "_backfill_start", None)
+        end = getattr(config, "_backfill_end", None) or trade_date
+        return start, min(end, trade_date)
+    start = trade_date - timedelta(days=_DAILY_DERIVE_LOOKBACK_DAYS - 1)
+    return start, trade_date - timedelta(days=1)
+
+
+@register_step("trading_status_derive", group="core", depends_on=["daily_bars"])
+def step_trading_status_derive(
+    config: Config, trade_date: date, run_id: str, context: dict
+) -> dict:
+    """Derive historical suspension rows from committed daily_bars gaps.
+
+    Stages `is_trading=false` rows into the trading_status dataset so the same
+    run's compact publishes them as a committed revision. Runs after daily_bars
+    (whose bars only become committed later in the run), handling a bounded
+    trailing window on daily runs and the full history window under
+    backfill/init.
+    """
+    from cnequity.derive.trading_status_history import derive_suspension_history
+
+    start, end = _trading_status_derive_scope(config, trade_date)
+    rows = derive_suspension_history(
+        config,
+        start=start,
+        end=end,
+        run_id=run_id,
+        batch_id="derived-daily",
+    )
+    return {"rows_read": rows, "rows_written": rows}
+
+
 def _is_all_a(symbol: str) -> bool:
     try:
         info = parse_symbol(symbol)

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -765,7 +765,7 @@ def test_audit_full_can_select_scoped_research_universe(cfg_path, monkeypatch):
 def test_derive_trading_status_and_orphans(cfg_path, monkeypatch):
     monkeypatch.setattr(
         "cnequity.derive.trading_status_history.derive_suspension_history",
-        lambda cfg, start=None, end=None: 7,
+        lambda cfg, start=None, end=None, run_id=None, **kwargs: 7,
     )
     result = CliRunner().invoke(
         cli,

--- a/tests/unit/test_compact_trading_status_rank.py
+++ b/tests/unit/test_compact_trading_status_rank.py
@@ -1,0 +1,203 @@
+"""compact merging of trading_status must preserve evidence rank.
+
+A newer ordinary EastMoney current-state snapshot (rank 2) must not overwrite
+a derived bar-gap suspension (rank 1), while an authority (rank 0: Baostock,
+a finalized same-session snapshot, or a delisting) must still be able to
+correct the derived row. Other datasets keep the old fetched_at-then-source
+precedence.
+"""
+
+from datetime import date, datetime, timezone
+
+import polars as pl
+
+from cnequity.config import Config
+from cnequity.domain.trading_status import (
+    DERIVED_BAR_GAP_SOURCE,
+    evidence_rank_expr,
+    status_evidence_rank,
+)
+from cnequity.query.canonical import dedupe_by_primary_key
+from cnequity.storage import StagingWriter, compact_dataset
+
+DAY = date(2024, 6, 28)
+MOMENT = datetime(2024, 6, 28, 15, 30, tzinfo=timezone.utc)
+
+
+def _status(symbol: str, is_trading: bool, source: str, fetched: str | None) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "symbol": [symbol],
+            "trade_date": [DAY],
+            "is_trading": [is_trading],
+            "status": ["normal" if is_trading else "suspended"],
+            "risk_warning": [None],
+            "source": [source],
+            "data_version": ["v1"],
+            "fetched_at": pl.Series([fetched], dtype=pl.Utf8).str.to_datetime(
+                time_unit="us", time_zone="UTC"
+            ),
+        }
+    )
+
+
+def _compact(cfg: Config, run_id: str, month: str, rows: list[pl.DataFrame]) -> pl.DataFrame:
+    """Stage *rows* for trading_status, compact the run, return the merged partition."""
+    part = cfg.curated_root / "trading_status" / f"trade_date={month}"
+    part.mkdir(parents=True, exist_ok=True)
+    writer = StagingWriter(cfg.staging_root)
+    for i, frame in enumerate(rows):
+        writer.write_batch("trading_status", run_id, f"batch-{i}", frame)
+    compact_dataset(
+        cfg.staging_root,
+        cfg.curated_root,
+        "trading_status",
+        run_id,
+        partition_col="trade_date",
+    )
+    return pl.read_parquet(part / "part-merged.parquet")
+
+
+def test_newer_snapshot_does_not_overwrite_derived_suspension(tmp_path):
+    cfg = Config(data_root=tmp_path / "data")
+    # Existing committed snapshot is the newest observation (July, late stamp),
+    # but it is a current-state snapshot stamped onto an older date (rank 2).
+    (cfg.curated_root / "trading_status" / "trade_date=2024-06").mkdir(parents=True)
+    _status("600519.SH", True, "eastmoney", "2024-07-01T08:00:00").write_parquet(
+        cfg.curated_root / "trading_status" / "trade_date=2024-06" / "part-merged.parquet"
+    )
+    out = _compact(
+        cfg,
+        "run-1",
+        "2024-06",
+        [_status("600519.SH", False, DERIVED_BAR_GAP_SOURCE, "2024-06-28T07:00:00")],
+    )
+    row = out.to_dicts()[0]
+    assert row["is_trading"] is False
+    assert row["source"] == DERIVED_BAR_GAP_SOURCE
+
+
+def test_derived_existing_survives_newer_snapshot_in_staging(tmp_path):
+    cfg = Config(data_root=tmp_path / "data")
+    (cfg.curated_root / "trading_status" / "trade_date=2024-06").mkdir(parents=True)
+    _status("600519.SH", False, DERIVED_BAR_GAP_SOURCE, "2024-06-28T07:00:00").write_parquet(
+        cfg.curated_root / "trading_status" / "trade_date=2024-06" / "part-merged.parquet"
+    )
+    out = _compact(
+        cfg,
+        "run-2",
+        "2024-06",
+        [_status("600519.SH", True, "eastmoney", "2024-07-01T08:00:00")],
+    )
+    row = out.to_dicts()[0]
+    assert row["is_trading"] is False
+    assert row["source"] == DERIVED_BAR_GAP_SOURCE
+
+
+def test_authority_source_corrects_derived_suspension(tmp_path):
+    cfg = Config(data_root=tmp_path / "data")
+    (cfg.curated_root / "trading_status" / "trade_date=2024-06").mkdir(parents=True)
+    _status("600519.SH", False, DERIVED_BAR_GAP_SOURCE, "2024-06-28T07:00:00").write_parquet(
+        cfg.curated_root / "trading_status" / "trade_date=2024-06" / "part-merged.parquet"
+    )
+    out = _compact(
+        cfg,
+        "run-3",
+        "2024-06",
+        [_status("600519.SH", True, "baostock", "2024-06-28T07:00:00")],
+    )
+    row = out.to_dicts()[0]
+    assert row["is_trading"] is True
+    assert row["source"] == "baostock"
+
+
+def test_finalized_same_session_snapshot_corrects_derived_suspension(tmp_path):
+    cfg = Config(data_root=tmp_path / "data")
+    (cfg.curated_root / "trading_status" / "trade_date=2024-06").mkdir(parents=True)
+    _status("600519.SH", False, DERIVED_BAR_GAP_SOURCE, "2024-06-28T07:00:00").write_parquet(
+        cfg.curated_root / "trading_status" / "trade_date=2024-06" / "part-merged.parquet"
+    )
+    # Fetched on the same session after 15:00 Shanghai (07:30 UTC) -> rank 0.
+    out = _compact(
+        cfg,
+        "run-4",
+        "2024-06",
+        [_status("600519.SH", True, "eastmoney", "2024-06-28T07:30:00")],
+    )
+    row = out.to_dicts()[0]
+    assert row["is_trading"] is True
+    assert row["source"] == "eastmoney"
+
+
+def test_evidence_rank_expr_matches_row_function(tmp_path):
+    """The columnar compact expression must agree with the row-wise authority."""
+    df = pl.DataFrame(
+        {
+            "symbol": ["A", "A", "A", "A", "A"],
+            "trade_date": [DAY] * 5,
+            "is_trading": [False] * 5,
+            "status": ["suspended"] * 5,
+            "risk_warning": [None] * 5,
+            "source": [
+                "baostock",
+                "eastmoney",
+                "eastmoney",
+                DERIVED_BAR_GAP_SOURCE,
+                "derived_delisted",
+            ],
+            "data_version": ["v1"] * 5,
+            "fetched_at": pl.Series(
+                [None, "2024-06-28T07:30:00", "2024-07-01T08:00:00", None, None],
+                dtype=pl.Utf8,
+            ).str.to_datetime(time_unit="us", time_zone="UTC"),
+        }
+    )
+    row_ranks = [status_evidence_rank(r) for r in df.to_dicts()]
+    col_ranks = df.with_columns(evidence_rank_expr("UTC").alias("rank")).get_column("rank")
+    assert col_ranks.to_list() == row_ranks == [0, 0, 2, 1, 0]
+
+
+def test_dedupe_by_primary_key_trading_status_rank(tmp_path):
+    """The shared canonical dedupe used by compact picks rank 1 over rank 2."""
+    frame = pl.DataFrame(
+        {
+            "symbol": ["600519.SH", "600519.SH"],
+            "trade_date": [DAY, DAY],
+            "is_trading": [True, False],
+            "status": ["normal", "suspended"],
+            "risk_warning": [None, None],
+            "source": ["eastmoney", DERIVED_BAR_GAP_SOURCE],
+            "data_version": ["v1", "v1"],
+            "fetched_at": pl.Series(
+                ["2024-07-01T08:00:00", "2024-06-28T07:00:00"], dtype=pl.Utf8
+            ).str.to_datetime(time_unit="us", time_zone="UTC"),
+        }
+    )
+    out = dedupe_by_primary_key(frame, "trading_status")
+    row = out.to_dicts()[0]
+    assert row["is_trading"] is False
+    assert row["source"] == DERIVED_BAR_GAP_SOURCE
+
+
+def test_non_trading_status_keeps_fetched_at_semantics(tmp_path):
+    """Regression: other datasets still prefer the freshest observation."""
+    frame = pl.DataFrame(
+        {
+            "symbol": ["600519.SH", "600519.SH"],
+            "trade_date": [DAY, DAY],
+            "open": [1.0, 1.0],
+            "high": [1.0, 1.0],
+            "low": [1.0, 1.0],
+            "close": [1.0, 1.0],
+            "volume": [100, 100],
+            "amount": [100.0, 100.0],
+            "source": ["tdx_protocol", "tdx_protocol"],
+            "data_version": ["v1", "v1"],
+            "fetched_at": pl.Series(
+                ["2024-07-01T00:00:00", "2024-06-28T00:00:00"], dtype=pl.Utf8
+            ).str.to_datetime(time_unit="us", time_zone="UTC"),
+        }
+    )
+    out = dedupe_by_primary_key(frame, "daily_bars")
+    assert out.height == 1
+    assert str(out["fetched_at"][0]).startswith("2024-07-01 00:00:00")

--- a/tests/unit/test_trading_status_history.py
+++ b/tests/unit/test_trading_status_history.py
@@ -1,12 +1,14 @@
 from datetime import date, datetime, timezone
 
 import polars as pl
+import pytest
 
+import cnequity.steps  # noqa: F401 — register steps used by step_compact
 from cnequity.config import Config
-from cnequity.derive.trading_status_history import (
-    derive_suspension_history,
-    status_evidence_rank,
-)
+from cnequity.derive.trading_status_history import derive_suspension_history
+from cnequity.domain.trading_status import DERIVED_BAR_GAP_SOURCE, status_evidence_rank
+from cnequity.query.reader import load
+from cnequity.steps.finalize import step_compact
 
 
 def test_status_evidence_precedence_is_pit_aware():
@@ -35,57 +37,85 @@ def test_status_evidence_precedence_is_pit_aware():
     assert status_evidence_rank({"source": "derived_bar_gap", "trade_date": trade_day}) == 1
 
 
-def test_derive_suspension_tie_break_is_not_file_order_dependent(tmp_path):
-    """Same-rank status rows choose the newest observation deterministically."""
+def _derive_and_compact(cfg: Config, run_id: str, trade_date: date, **kwargs) -> int:
+    """Stage derived rows and publish them through a real compact step."""
+    n = derive_suspension_history(cfg, run_id=run_id, **kwargs)
+    if n:
+        step_compact(cfg, trade_date, run_id, {})
+    return n
+
+
+def test_derive_stages_rows_with_status_schema(tmp_path):
+    """3.1 — derived rows land in staging with the trading_status schema."""
     root = tmp_path / "data"
     cfg = Config(data_root=root)
-    day = date(2024, 6, 27)
-    days = [date(2024, 6, 26), day, date(2024, 6, 28)]
-    for current in days:
+    days = [date(2024, 6, 26), date(2024, 6, 27), date(2024, 6, 28)]
+    for d in days:
         _write(
             root,
             "trading_calendar",
             "trade_date",
-            current.isoformat(),
+            d.isoformat(),
             pl.DataFrame(
                 {
-                    "trade_date": [current],
+                    "trade_date": [d],
                     "is_trading": [True],
                     "source": ["seed"],
                     "data_version": ["v1"],
-                    "fetched_at": ["2024-06-27T00:00:00+00:00"],
+                    "fetched_at": ["2024-06-28T00:00:00+00:00"],
                 }
             ),
         )
-        rows = [
-            {
-                "symbol": "600519.SH",
-                "trade_date": current,
-                "open": 1.0,
-                "high": 1.0,
-                "low": 1.0,
-                "close": 1.0,
-                "volume": 100,
-                "amount": 100.0,
-                "source": "tdx_protocol",
-                "data_version": "v1",
-                "fetched_at": "2024-06-27T00:00:00+00:00",
-            }
-        ]
-        if current != day:
-            rows.append({**rows[0], "symbol": "000001.SZ"})
-        _write(root, "daily_bars", "trade_date", current.isoformat(), pl.DataFrame(rows))
-    (root / "curated" / "instruments").mkdir(parents=True, exist_ok=True)
-    pl.DataFrame(
-        {
-            "symbol": ["600519.SH", "000001.SZ"],
-            "list_date": [date(2010, 1, 1), date(2010, 1, 1)],
-            "delist_date": [None, None],
-        }
-    ).write_parquet(root / "curated" / "instruments" / "part-merged.parquet")
+    for d in days:
+        rows = [_bar("600519.SH", d)]
+        if d != date(2024, 6, 27):
+            rows.append(_bar("000001.SZ", d))
+        _write(root, "daily_bars", "trade_date", d.isoformat(), pl.DataFrame(rows))
+    _write_instruments(root, ["600519.SH", "000001.SZ"])
 
-    # Both rows are final same-session evidence.  The newer one must win even
-    # when it is written first in the existing partition.
+    n = derive_suspension_history(cfg, run_id="run-a")
+    assert n == 1
+
+    staged = list((cfg.staging_root / "trading_status" / "run_id=run-a").rglob("*.parquet"))
+    assert len(staged) == 1
+    frame = pl.read_parquet(staged[0])
+    assert frame.schema.names() == [
+        "symbol",
+        "trade_date",
+        "is_trading",
+        "status",
+        "risk_warning",
+        "source",
+        "data_version",
+        "fetched_at",
+    ]
+    assert frame["source"].to_list() == [DERIVED_BAR_GAP_SOURCE]
+    assert frame["status"].to_list() == ["suspended"]
+    assert not (cfg.curated_root / "trading_status").exists() or not any(
+        (cfg.curated_root / "trading_status").rglob("*.parquet")
+    )
+
+
+def test_derive_publish_is_visible_to_committed_readers(tmp_path):
+    """3.2 — after derive + compact, load_curated_trading_status sees is_trading=false."""
+    root = tmp_path / "data"
+    cfg = Config(data_root=root)
+    days = [date(2024, 6, 26), date(2024, 6, 27), date(2024, 6, 28)]
+    for d in days:
+        _write(
+            root,
+            "trading_calendar",
+            "trade_date",
+            d.isoformat(),
+            _calendar_row(d),
+        )
+    for d in days:
+        rows = [_bar("600519.SH", d)]
+        if d != date(2024, 6, 27):
+            rows.append(_bar("000001.SZ", d))
+        _write(root, "daily_bars", "trade_date", d.isoformat(), pl.DataFrame(rows))
+    _write_instruments(root, ["600519.SH", "000001.SZ"])
+    # Existing authored snapshot to prove compact preserves it alongside derive.
     _write(
         root,
         "trading_status",
@@ -93,25 +123,112 @@ def test_derive_suspension_tie_break_is_not_file_order_dependent(tmp_path):
         "2024-06",
         pl.DataFrame(
             {
-                "symbol": ["600519.SH", "600519.SH"],
-                "trade_date": [day, day],
-                "is_trading": [True, False],
-                "status": ["N", "suspended"],
-                "source": ["eastmoney", "eastmoney"],
-                "data_version": ["v1", "v1"],
-                "fetched_at": [
-                    "2024-06-27T07:30:00+00:00",
-                    "2024-06-27T08:30:00+00:00",
-                ],
+                "symbol": ["600519.SH"],
+                "trade_date": [date(2024, 6, 26)],
+                "is_trading": [True],
+                "status": ["normal"],
+                "risk_warning": [False],
+                "source": ["eastmoney"],
+                "data_version": ["v1"],
+                "fetched_at": ["2024-06-28T00:00:00+00:00"],
             }
         ),
     )
 
-    assert derive_suspension_history(cfg) == 1
-    out = pl.read_parquet(
+    assert _derive_and_compact(cfg, "run-b", days[-1]) == 1
+
+    committed = load(
+        "trading_status",
+        data_root=cfg.data_root,
+        start=days[0],
+        end=days[-1],
+    )
+    susp = committed.filter(pl.col("status") == "suspended")
+    assert susp.height == 1
+    row = susp.to_dicts()[0]
+    assert row["symbol"] == "000001.SZ"
+    assert row["trade_date"] == date(2024, 6, 27)
+    assert row["is_trading"] is False
+    assert row["source"] == DERIVED_BAR_GAP_SOURCE
+    assert committed.filter(pl.col("symbol") == "600519.SH").height == 1
+
+
+def test_repeat_compact_keeps_derived_suspension_rows(tmp_path):
+    """3.3 — a second, later compact does not rebuild away the derived row."""
+    root = tmp_path / "data"
+    cfg = Config(data_root=root)
+    days = [date(2024, 6, 26), date(2024, 6, 27), date(2024, 6, 28)]
+    for d in days:
+        _write(root, "trading_calendar", "trade_date", d.isoformat(), _calendar_row(d))
+    for d in days:
+        rows = [_bar("600519.SH", d)]
+        if d != date(2024, 6, 27):
+            rows.append(_bar("000001.SZ", d))
+        _write(root, "daily_bars", "trade_date", d.isoformat(), pl.DataFrame(rows))
+    _write_instruments(root, ["600519.SH", "000001.SZ"])
+
+    assert _derive_and_compact(cfg, "run-c", days[-1]) == 1
+    step_compact(cfg, days[-1], "run-c", {})  # second compact over the same run
+
+    committed = load("trading_status", data_root=cfg.data_root, start=days[0], end=days[-1])
+    susp = committed.filter(pl.col("source") == DERIVED_BAR_GAP_SOURCE)
+    assert susp.height == 1
+    assert susp["symbol"].to_list() == ["000001.SZ"]
+    assert susp["trade_date"].to_list() == [date(2024, 6, 27)]
+
+
+def test_derive_suspension_from_bar_gaps(tmp_path):
+    root = tmp_path / "data"
+    cfg = Config(data_root=root)
+    days = [date(2024, 6, 26), date(2024, 6, 27), date(2024, 6, 28)]
+    for d in days:
+        _write(root, "trading_calendar", "trade_date", d.isoformat(), _calendar_row(d))
+    for d in days:
+        rows = [_bar("600519.SH", d)]
+        if d != date(2024, 6, 27):
+            rows.append(_bar("000001.SZ", d))
+        _write(root, "daily_bars", "trade_date", d.isoformat(), pl.DataFrame(rows))
+    _write_instruments(root, ["600519.SH", "000001.SZ"])
+    _write(
+        root,
+        "trading_status",
+        "trade_date",
+        "2024-06",
+        pl.DataFrame(
+            {
+                "symbol": ["600519.SH"],
+                "trade_date": [date(2024, 6, 26)],
+                "is_trading": [True],
+                "status": ["normal"],
+                "risk_warning": [False],
+                "source": ["eastmoney"],
+                "data_version": ["v1"],
+                "fetched_at": ["2024-06-28T00:00:00+00:00"],
+            }
+        ),
+    )
+
+    assert _derive_and_compact(cfg, "run-d", days[-1]) == 1
+
+    # trading_status stays month-partitioned in curated; staged derive is flat.
+    ts = pl.read_parquet(
         root / "curated" / "trading_status" / "trade_date=2024-06" / "part-merged.parquet"
     )
-    assert out.filter(pl.col("symbol") == "600519.SH")["status"].to_list() == ["suspended"]
+    assert (
+        ts.filter(
+            (pl.col("symbol") == "600519.SH") & (pl.col("trade_date") == date(2024, 6, 26))
+        ).height
+        == 1
+    )
+    assert [path.name for path in (root / "curated" / "trading_status").rglob("*.parquet")] == [
+        "part-merged.parquet"
+    ]
+    susp = ts.filter(pl.col("status") == "suspended")
+    assert susp.height == 1
+    assert susp["symbol"][0] == "000001.SZ"
+    assert susp["trade_date"][0] == date(2024, 6, 27)
+    assert susp["is_trading"][0] is False
+    assert susp["source"][0] == DERIVED_BAR_GAP_SOURCE
 
 
 def test_derive_suspension_uses_canonical_calendar_rows(tmp_path):
@@ -181,137 +298,34 @@ def test_derive_suspension_uses_canonical_calendar_rows(tmp_path):
                 }
             ),
         )
-    instruments = root / "curated" / "instruments"
-    instruments.mkdir(parents=True, exist_ok=True)
-    pl.DataFrame(
-        {
-            "symbol": ["600519.SH"],
-            "list_date": [date(2010, 1, 1)],
-            "delist_date": [None],
-        }
-    ).write_parquet(instruments / "part-merged.parquet")
-
-    assert derive_suspension_history(cfg) == 0
-
-
-def _write(root, dataset, partition_col, val, df):
-    d = root / "curated" / dataset / f"{partition_col}={val}"
-    d.mkdir(parents=True, exist_ok=True)
-    df.write_parquet(d / "part-merged.parquet")
-
-
-def test_derive_suspension_from_bar_gaps(tmp_path):
-    root = tmp_path / "data"
-    cfg = Config(data_root=root)
-    # calendar: 3 trading days
-    days = [date(2024, 6, 26), date(2024, 6, 27), date(2024, 6, 28)]
-    for d in days:
-        _write(
-            root,
-            "trading_calendar",
-            "trade_date",
-            d.isoformat(),
-            pl.DataFrame(
-                {
-                    "trade_date": [d],
-                    "is_trading": [True],
-                    "source": ["seed"],
-                    "data_version": ["v1"],
-                    "fetched_at": ["2024-06-28T00:00:00+00:00"],
-                }
-            ),
-        )
-
-    # bars: 600519 trades all 3 days; 000001 missing the middle day (suspended)
-    def bar(sym, d):
-        return {
-            "symbol": sym,
-            "trade_date": d,
-            "open": 1.0,
-            "high": 1.0,
-            "low": 1.0,
-            "close": 1.0,
-            "volume": 1,
-            "amount": 1.0,
-            "source": "tdx_protocol",
-            "data_version": "v1",
-            "fetched_at": "2024-06-28T00:00:00+00:00",
-        }
-
-    for d in days:
-        rows = [bar("600519.SH", d)]
-        if d != date(2024, 6, 27):
-            rows.append(bar("000001.SZ", d))
-        _write(root, "daily_bars", "trade_date", d.isoformat(), pl.DataFrame(rows))
-    # instruments: both listed before window, not delisted
     (root / "curated" / "instruments").mkdir(parents=True, exist_ok=True)
     pl.DataFrame(
         {
             "symbol": ["600519.SH"],
-            "name": ["A"],
-            "exchange": ["SH"],
-            "asset_type": ["stock"],
             "list_date": [date(2010, 1, 1)],
             "delist_date": [None],
-            "prev_symbol": [None],
-            "source": ["tdx"],
-            "data_version": ["v1"],
-            "fetched_at": ["2024-06-28T00:00:00+00:00"],
         }
     ).write_parquet(root / "curated" / "instruments" / "part-merged.parquet")
-    nested_instruments = root / "curated" / "instruments" / ".old-fragments"
-    nested_instruments.mkdir()
+
+    assert derive_suspension_history(cfg, run_id="run-e") == 0
+
+
+def _write_instruments(root, symbols):
+    (root / "curated" / "instruments").mkdir(parents=True, exist_ok=True)
     pl.DataFrame(
         {
-            "symbol": ["000001.SZ"],
-            "name": ["B"],
-            "exchange": ["SZ"],
-            "asset_type": ["stock"],
-            "list_date": [date(2010, 1, 1)],
-            "delist_date": [None],
-            "prev_symbol": [None],
-            "source": ["tdx"],
-            "data_version": ["v1"],
-            "fetched_at": ["2024-06-28T00:00:00+00:00"],
+            "symbol": symbols,
+            "name": ["A", "B"] if len(symbols) == 2 else ["A"],
+            "exchange": [s.split(".")[1] for s in symbols],
+            "asset_type": ["stock"] * len(symbols),
+            "list_date": [date(2010, 1, 1)] * len(symbols),
+            "delist_date": [None] * len(symbols),
+            "prev_symbol": [None] * len(symbols),
+            "source": ["tdx"] * len(symbols),
+            "data_version": ["v1"] * len(symbols),
+            "fetched_at": ["2024-06-28T00:00:00+00:00"] * len(symbols),
         }
-    ).write_parquet(nested_instruments / "part-old.parquet")
-
-    existing = root / "curated" / "trading_status" / "trade_date=2024-06" / "fragments"
-    existing.mkdir(parents=True, exist_ok=True)
-    pl.DataFrame(
-        {
-            "symbol": ["600519.SH"],
-            "trade_date": [date(2024, 6, 26)],
-            "is_trading": [True],
-            "status": ["N"],
-            "source": ["eastmoney"],
-            "data_version": ["v1"],
-            "fetched_at": ["2024-06-28T00:00:00+00:00"],
-        }
-    ).write_parquet(existing / "part-old.parquet")
-
-    n = derive_suspension_history(cfg)
-    assert n == 1  # only 000001 on 2024-06-27
-
-    # trading_status is month-partitioned (DatasetSpec); never write day dirs.
-    month_dir = root / "curated" / "trading_status" / "trade_date=2024-06"
-    assert month_dir.is_dir()
-    assert not (root / "curated" / "trading_status" / "trade_date=2024-06-27").exists()
-
-    ts = pl.read_parquet(month_dir / "part-merged.parquet")
-    assert (
-        ts.filter(
-            (pl.col("symbol") == "600519.SH") & (pl.col("trade_date") == date(2024, 6, 26))
-        ).height
-        == 1
-    )
-    assert [path.name for path in month_dir.rglob("*.parquet")] == ["part-merged.parquet"]
-    susp = ts.filter(pl.col("status") == "suspended")
-    assert susp.height == 1
-    assert susp["symbol"][0] == "000001.SZ"
-    assert susp["trade_date"][0] == date(2024, 6, 27)
-    assert susp["is_trading"][0] is False
-    assert susp["source"][0] == "derived_bar_gap"
+    ).write_parquet(root / "curated" / "instruments" / "part-merged.parquet")
 
 
 def test_derive_suspension_treats_zero_volume_placeholder_as_missing(tmp_path):
@@ -319,71 +333,25 @@ def test_derive_suspension_treats_zero_volume_placeholder_as_missing(tmp_path):
     cfg = Config(data_root=root)
     days = [date(2024, 6, 27), date(2024, 6, 28)]
     for d in days:
-        _write(
-            root,
-            "trading_calendar",
-            "trade_date",
-            d.isoformat(),
-            pl.DataFrame(
-                {
-                    "trade_date": [d],
-                    "is_trading": [True],
-                    "source": ["seed"],
-                    "data_version": ["v1"],
-                    "fetched_at": ["2024-06-28T00:00:00+00:00"],
-                }
-            ),
-        )
-
-    def bar(day: date, volume: int) -> dict:
-        return {
-            "symbol": "000001.SZ",
-            "trade_date": day,
-            "open": 10.0,
-            "high": 10.0,
-            "low": 10.0,
-            "close": 10.0,
-            "volume": volume,
-            "amount": float(volume) * 10.0,
-            "source": "tdx_protocol",
-            "data_version": "v1",
-            "fetched_at": "2024-06-28T00:00:00+00:00",
-        }
-
+        _write(root, "trading_calendar", "trade_date", d.isoformat(), _calendar_row(d))
     _write(
         root,
         "daily_bars",
         "trade_date",
         "2024-06-27",
-        pl.DataFrame([bar(days[0], 0)]),
+        pl.DataFrame([_bar("000001.SZ", days[0], volume=0)]),
     )
     _write(
         root,
         "daily_bars",
         "trade_date",
         "2024-06-28",
-        pl.DataFrame([bar(days[1], 100)]),
+        pl.DataFrame([_bar("000001.SZ", days[1], volume=100)]),
     )
-    (root / "curated" / "instruments").mkdir(parents=True, exist_ok=True)
-    pl.DataFrame(
-        {
-            "symbol": ["000001.SZ"],
-            "name": ["B"],
-            "exchange": ["SZ"],
-            "asset_type": ["stock"],
-            "list_date": [date(2010, 1, 1)],
-            "delist_date": [None],
-            "prev_symbol": [None],
-            "source": ["tdx"],
-            "data_version": ["v1"],
-            "fetched_at": ["2024-06-28T00:00:00+00:00"],
-        }
-    ).write_parquet(root / "curated" / "instruments" / "part-merged.parquet")
+    _write_instruments(root, ["000001.SZ"])
 
-    assert derive_suspension_history(cfg) == 1
-    status = pl.read_parquet(
-        root / "curated" / "trading_status" / "trade_date=2024-06" / "part-merged.parquet"
-    )
+    assert _derive_and_compact(cfg, "run-f", days[-1]) == 1
+    status = load("trading_status", data_root=cfg.data_root, start=days[0], end=days[-1])
     assert status.filter(pl.col("status") == "suspended")["trade_date"].to_list() == [
         date(2024, 6, 27)
     ]
@@ -394,63 +362,20 @@ def test_derive_suspension_ignores_placeholder_only_symbol(tmp_path):
     cfg = Config(data_root=root)
     days = [date(2024, 6, 27), date(2024, 6, 28)]
     for d in days:
-        _write(
-            root,
-            "trading_calendar",
-            "trade_date",
-            d.isoformat(),
-            pl.DataFrame(
-                {
-                    "trade_date": [d],
-                    "is_trading": [True],
-                    "source": ["seed"],
-                    "data_version": ["v1"],
-                    "fetched_at": ["2024-06-28T00:00:00+00:00"],
-                }
-            ),
-        )
-
+        _write(root, "trading_calendar", "trade_date", d.isoformat(), _calendar_row(d))
     rows = []
     for symbol, volume in (("600519.SH", 100), ("000001.SZ", 0)):
         for d in days:
-            rows.append(
-                {
-                    "symbol": symbol,
-                    "trade_date": d,
-                    "open": 1.0,
-                    "high": 1.0,
-                    "low": 1.0,
-                    "close": 1.0,
-                    "volume": volume,
-                    "amount": float(volume),
-                    "source": "tdx_protocol",
-                    "data_version": "v1",
-                    "fetched_at": "2024-06-28T00:00:00+00:00",
-                }
-            )
-    _write(
-        root,
-        "daily_bars",
-        "trade_date",
-        "2024-06",
-        pl.DataFrame(rows),
-    )
+            rows.append(_bar(symbol, d, volume=volume))
+    _write(root, "daily_bars", "trade_date", "2024-06", pl.DataFrame(rows))
+    _write_instruments(root, ["600519.SH", "000001.SZ"])
 
-    (root / "curated" / "instruments").mkdir(parents=True, exist_ok=True)
-    pl.DataFrame(
-        {
-            "symbol": ["600519.SH", "000001.SZ"],
-            "list_date": [date(2010, 1, 1), date(2010, 1, 1)],
-            "delist_date": [None, None],
-        }
-    ).write_parquet(root / "curated" / "instruments" / "part-merged.parquet")
-
-    assert derive_suspension_history(cfg) == 0
+    assert derive_suspension_history(cfg, run_id="run-g") == 0
 
 
 def test_derive_suspension_empty_lake(tmp_path):
     cfg = Config(data_root=tmp_path / "data")
-    assert derive_suspension_history(cfg) == 0
+    assert derive_suspension_history(cfg, run_id="run-h") == 0
 
 
 def test_derive_suspension_respects_end_window(tmp_path):
@@ -463,61 +388,27 @@ def test_derive_suspension_respects_end_window(tmp_path):
         date(2016, 1, 4),
         date(2016, 1, 5),
     ]
-
-    def bar(sym, d):
-        return {
-            "symbol": sym,
-            "trade_date": d,
-            "open": 1.0,
-            "high": 1.0,
-            "low": 1.0,
-            "close": 1.0,
-            "volume": 1,
-            "amount": 1.0,
-            "source": "tdx_protocol",
-            "data_version": "v1",
-            "fetched_at": "2016-01-05T00:00:00+00:00",
-        }
-
     for d in days:
         _write(
             root,
             "trading_calendar",
             "trade_date",
             d.isoformat(),
-            pl.DataFrame(
-                {
-                    "trade_date": [d],
-                    "is_trading": [True],
-                    "source": ["seed"],
-                    "data_version": ["v1"],
-                    "fetched_at": ["2016-01-05T00:00:00+00:00"],
-                }
-            ),
+            _calendar_row(d, fetched="2016-01-05T00:00:00+00:00"),
         )
-        # 000001 missing 2015-12-31 and 2016-01-04
-        rows = [bar("600519.SH", d)]
+        rows = [_bar("600519.SH", d)]
         if d not in (date(2015, 12, 31), date(2016, 1, 4)):
-            rows.append(bar("000001.SZ", d))
+            rows.append(_bar("000001.SZ", d))
         _write(root, "daily_bars", "trade_date", d.isoformat(), pl.DataFrame(rows))
+    _write_instruments(root, ["600519.SH", "000001.SZ"])
 
-    (root / "curated" / "instruments").mkdir(parents=True, exist_ok=True)
-    pl.DataFrame(
-        {
-            "symbol": ["600519.SH", "000001.SZ"],
-            "name": ["A", "B"],
-            "exchange": ["SH", "SZ"],
-            "asset_type": ["stock", "stock"],
-            "list_date": [date(2010, 1, 1), date(2010, 1, 1)],
-            "delist_date": [None, None],
-            "prev_symbol": [None, None],
-            "source": ["tdx", "tdx"],
-            "data_version": ["v1", "v1"],
-            "fetched_at": ["2016-01-05T00:00:00+00:00"] * 2,
-        }
-    ).write_parquet(root / "curated" / "instruments" / "part-merged.parquet")
-
-    n = derive_suspension_history(cfg, start=date(2015, 1, 1), end=date(2015, 12, 31))
+    n = _derive_and_compact(
+        cfg,
+        "run-i",
+        days[-1],
+        start=date(2015, 1, 1),
+        end=date(2015, 12, 31),
+    )
     assert n == 1
     ts = pl.read_parquet(
         root / "curated" / "trading_status" / "trade_date=2015-12" / "part-merged.parquet"
@@ -526,3 +417,94 @@ def test_derive_suspension_respects_end_window(tmp_path):
         date(2015, 12, 31)
     ]
     assert not (root / "curated" / "trading_status" / "trade_date=2016-01").exists()
+
+
+def test_derive_rejects_unfinished_today_session(tmp_path):
+    root = tmp_path / "data"
+    cfg = Config(data_root=root)
+    today = date(2026, 9, 3)  # a Thursday; marked trading below for determinism
+    _write(
+        root,
+        "trading_calendar",
+        "trade_date",
+        today.isoformat(),
+        pl.DataFrame(
+            {
+                "trade_date": [today],
+                "is_trading": [True],
+                "source": ["seed"],
+                "data_version": ["v1"],
+            }
+        ),
+    )
+    now = datetime(2026, 9, 3, 6, 0, tzinfo=timezone.utc)  # 14:00 Shanghai
+
+    with pytest.raises(RuntimeError, match="not final until 15:05 Asia/Shanghai"):
+        derive_suspension_history(cfg, end=today, run_id="run-j", now=now)
+
+
+def test_derive_allows_finalized_session_and_historical_end(tmp_path):
+    root = tmp_path / "data"
+    cfg = Config(data_root=root)
+    today = date(2026, 9, 3)
+    _write(
+        root,
+        "trading_calendar",
+        "trade_date",
+        today.isoformat(),
+        pl.DataFrame(
+            {
+                "trade_date": [today],
+                "is_trading": [True],
+                "source": ["seed"],
+                "data_version": ["v1"],
+            }
+        ),
+    )
+    # 07:05 UTC -> 15:05 Shanghai, past the settlement buffer.
+    now = datetime(2026, 9, 3, 7, 5, tzinfo=timezone.utc)
+    assert derive_suspension_history(cfg, end=today, run_id="run-k", now=now) == 0
+    # Historical end never trips the guard, day or night.
+    assert (
+        derive_suspension_history(
+            cfg,
+            end=date(2024, 6, 28),
+            run_id="run-l",
+            now=datetime(2026, 9, 3, 6, 0, tzinfo=timezone.utc),
+        )
+        == 0
+    )
+
+
+def _calendar_row(d: date, *, fetched: str = "2024-06-28T00:00:00+00:00") -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "trade_date": [d],
+            "is_trading": [True],
+            "source": ["seed"],
+            "data_version": ["v1"],
+            "fetched_at": [fetched],
+        }
+    )
+
+
+def _bar(symbol: str, d: date, *, volume: int = 1) -> dict:
+    return {
+        "symbol": symbol,
+        "trade_date": d,
+        "open": 1.0,
+        "high": 1.0,
+        "low": 1.0,
+        "close": 1.0,
+        "volume": volume,
+        "amount": 1.0,
+        "source": "tdx_protocol",
+        "data_version": "v1",
+        "fetched_at": "2024-06-28T00:00:00+00:00",
+    }
+
+
+def _write(root, dataset, partition_col, val, df):
+    d = root / "curated" / dataset / f"{partition_col}={val}"
+    d.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(d / "part-merged.parquet")


### PR DESCRIPTION
对应 OpenSpec 变更 `trading-status-suspension-derive-channel`。

## 摘要
`derive_suspension_history` 根据 `daily_bars` 的交易缺口反推历史停牌日,但此前把 `is_trading=false` 行**直写进可变的 curated 目录、从不生成修订(revision)**:committed 读者永远看不到这些行,且下一次 compact 会从旧快照重建分区把它们冲掉。这正是 `600984.SH` daily_bars interior-gap 无法通过 checkpoint 的根因——interior-gap 校验要求 **已提交的** `is_trading=false` 显式豁免证据,而反推出的行从未进入提交流程。

本变更将派生停牌行接入正式的 `staging → compact → commit` 通道:committed 读者可见、后续 compact 不再冲掉,并把该维护固化为每日自动环节。

## 变更内容
- **提交通道**:`derive_suspension_history` 改为写入 `StagingWriter`(`trading_status` 数据集);compact 按证据等级合并并发布 committed 修订。
- **证据等级合并**:将 `status_evidence_rank` 抽到 `domain/trading_status.py`(并新增列式等价实现 `evidence_rank_expr`);compact / canonical 去重对 `trading_status` 优先按证据等级排序(权威 > 派生),使"更新的普通 EastMoney 快照(rank 2)"不会覆盖 `derived_bar_gap` 派生行(rank 1),同时 rank 0 权威(Baostock / 已收盘当日快照 / 退市)仍可修正派生行。
- **共享未收盘防护**:抽取 `reject_unfinished_eod_window`(A 股 15:05 上海时间收盘线)到 `steps/common.py`;daily_bars 与 derive 路径复用,杜绝盘中把"今天还没出 bar"误判为停牌。
- **每日 + init 调度**:注册 `trading_status_derive` 步骤挂入每日 core group(`daily_bars` 之后、`compact` 之前,尾窗 30 天),并新增 init `phase5_derive_and_publish`(bar compact 提交后做全历史反推,再 compact 发布)。
- **CLI**:`cne derive trading_status` 改经自有迷你 run 完成 staging→compact→commit,不再直写可变目录。

## 验证
- 新增/更新单测:`tests/unit/test_compact_trading_status_rank.py` 与 `tests/unit/test_trading_status_history.py`(staging 可见性、重复 compact 不冲掉、权威修正派生、未收盘防护)。
- 全量单测 `2600 passed`(仅 3 项 `test_snapshot_archives.py` 因环境缺少 `zstd/_zstd` 失败,与本次改动无关)。
- `ruff check` / `ruff format --check` 通过。
- 实盘湖验证:`cne derive trading_status` 一次补齐 758 行/139 标的;compact 后 committed 剩余 729 行(29 条被 rank 0 权威源按设计覆盖修正),`trading_status` 修订号 4 → 5。
- `cne backfill daily_bars --symbols 600984.SH --start 2026-08-11 --end 2026-08-26` 现可 `success` 完成——10 个停牌会话凭已提交的 `is_trading=false` 被认证为 no-data,不再报 "refusing to checkpoint"。
- `cne audit --full`:派生行未引入任何新 findings(其余 findings 均为湖本身既有的运营/数据问题)。

## 涉及文件
- `src/cnequity/domain/trading_status.py` — 共享证据等级 + 列式表达式
- `src/cnequity/domain/canonical.py` — trading_status 按证据等级优先合并
- `src/cnequity/derive/trading_status_history.py` — staging 通道
- `src/cnequity/steps/common.py` / `steps/bars.py` — 共享未收盘防护
- `src/cnequity/steps/reference.py` — 注册 `trading_status_derive` 步骤
- `src/cnequity/orchestrator/init_phases.py` — 新增 `phase5_derive_and_publish`
- `src/cnequity/cli/maintain_cmds.py` — CLI derive 走提交通道
- `configs/cnequity.example.toml` 及打包模板 — 每日 core group
- `tests/…` — 单元测试
- `openspec/changes/trading-status-suspension-derive-channel/` — 变更规范

## 检查清单
- [x] 代码改动严格限定于 OpenSpec 变更范围
- [x] 新增/更新测试并通过
- [x] lint + 格式化通过
- [x] 实盘湖端到端验证(derive/compact/backfill/audit)
