### PR TITLE
fix(steps): 非交易日允许公告增量抓取空结果容差

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ the project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **日历日公告增量抓取容空（非交易日容忍零行）。** `announcement_index` 等日历日披露数据集在增量抓取时感知日历属性：周日或法定节假日无公告时允许 0 行跳过并记录日志，正常交易日返回 0 行继续严格抛出 `RuntimeError`（守住数据源故障的 Fail-Loud 警报防护）。
 - **Checks against the bodies that publish the numbers, not a second vendor.**
   Every price arbiter in the lake compared one redistributor against another,
   which can show that two feeds do not differ but never that either is right.

--- a/openspec/changes/announcement-calendar-empty-tolerance/.openspec.yaml
+++ b/openspec/changes/announcement-calendar-empty-tolerance/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/announcement-calendar-empty-tolerance/design.md
+++ b/openspec/changes/announcement-calendar-empty-tolerance/design.md
@@ -1,0 +1,87 @@
+## Context
+
+`announcement_index` 是一个记录全市场 A 股上市公司披露公告索引的关键数据集。
+在 [`src/cnequity/steps/common.py:68`](file:///home/bladestone/devspace/gitcode/stockagent/CNEquity/src/cnequity/steps/common.py#L68) 中：
+```python
+CALENDAR_DATE_DATASETS = frozenset({"announcement_index", "regulatory_events"})
+```
+系统通过 `incremental_trade_dates` 展开自然日历序列（包括周末），以确保抓取到周六及假期的上市公司公告。
+
+但在 [`src/cnequity/steps/common.py:482-484`](file:///home/bladestone/devspace/gitcode/stockagent/CNEquity/src/cnequity/steps/common.py#L482) 的 `fetch_incremental_daily` 中：
+```python
+for d in fetch_dates:
+    part = fetch_fn(d)
+    if part.is_empty():
+        if not allow_empty:
+            raise RuntimeError(f"{dataset}: no rows returned for {d.isoformat()}")
+```
+当增量窗口跨越周日（如 2026-08-02）时，CNINFO 官方当天客观上全集为 0 条公告。由于 `step_announcement_index` 默认 `allow_empty=False`，导致抛错 `RuntimeError: announcement_index: no rows returned for 2026-08-02`。
+
+同时，实测排查表明：**正常交易日**全天公告量在 400 ~ 22,000+ 条之间，绝对不会为 0。如果正常交易日返回 0 行，必须作为源故障大声报错（Fail Loud）。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 让 `fetch_incremental_daily` 感知日历属性：对于 `CALENDAR_DATE_DATASETS`，非交易日（周末/法定节假日）无数据时合法跳过，不再抛出 `RuntimeError`。
+- 保留交易日严格校验：若正常交易日（`is_trading_day == True`）返回 0 行，依然抛出 `RuntimeError` 阻断流水线。
+- 确保非交易日有数据（如周六披露）能够正常合并入库，Parquet 落地与 watermark 语义完全正确。
+
+**Non-Goals:**
+- 不将 `allow_empty=True` 粗暴地应用于全天候（避免工作日源宕机静默通过）。
+- 不改动非自然日数据集（如行情 `daily_bars`、资金流 `fund_flow` 等交易日数据集依旧只遍历交易日）。
+- 不改动底层 CNINFO HTTP 请求和 category 桶分页逻辑。
+
+## Decisions
+
+### D1. 决策点：在 `fetch_incremental_daily` 核心循环中引入日历感知放行
+
+在 `fetch_incremental_daily` 中，针对 `part.is_empty()` 且 `not allow_empty` 的分支增加判定：
+```python
+if part.is_empty():
+    if not allow_empty:
+        if dataset in CALENDAR_DATE_DATASETS and not is_trading_day(config, d):
+            logger.info(
+                "%s: 0 rows returned for non-trading calendar date %s (tolerated)",
+                dataset,
+                d.isoformat(),
+            )
+            continue
+        raise RuntimeError(f"{dataset}: no rows returned for {d.isoformat()}")
+```
+
+- **为什么选在 `fetch_incremental_daily` 而不是由 step 传递 `allow_empty=True`？**
+  - 如果在 step 中传递 `allow_empty=True`，则 `fetch_incremental_daily` 对整个增量批次都会放行，万一当前批次中某个**周二或周三交易日**因为 CNINFO 故障返回了 0 行，就会被静默跳过而失去告警防护。
+  - 在 `fetch_incremental_daily` 内部逐日循环时判断 `is_trading_day(config, d)`，能够做到**天级别的精准区分**：周日跳过，周一严格报错。
+  - [`is_trading_day`](file:///home/bladestone/devspace/gitcode/stockagent/CNEquity/src/cnequity/steps/common.py#L314) 本身就定义在 `common.py`，无跨模块引入开销，且优先使用湖中同步的 `trading_calendar`，备用种子文件，判断极其可靠。
+
+### D2. 水印与空洞语义一致性保证
+
+- **跨多日增量场景（如周五到周一）**：
+  - `fetch_dates` = [周五, 周六, 周日, 周一]
+  - 周五：有数据（如 1300 条），加入 `frames`
+  - 周六：有数据（如 1371 条），加入 `frames`
+  - 周日：0 行，非交易日跳过，不加入 `frames`
+  - 周一：有数据（如 477 条），加入 `frames`
+  - `combined = pl.concat(frames)` 包含周五、周六、周一的数据，正常写入 staging 并 compact。
+  - `finalize` 中 `_watermark_date_for` 提取湖中最大日期（周一），watermark 推进至周一。周日没有任何未解空洞。
+- **单日非交易日运行场景（如周日当天执行流水线）**：
+  - `fetch_dates` = [周日]
+  - 周日返回 0 行，`frames` 为空，`fetch_incremental_daily` 返回 `(empty_df, [])`。
+  - `run_incremental_fetched` 接收到空 DataFrame，返回 `rows_written: 0`。
+  - 湖中没有新数据，watermark 保持在周六（或上一交易日）。
+  - 下周一运行流水线时，自动从周日开始追赶并与周一数据合并，保持幂等与自愈。
+
+## Risks / Trade-offs
+
+- **风险：交易日历判断不准确？**
+  - `is_trading_day(config, d)` 先查 weekend (`weekday >= 5`) 和已知 `CLOSED_DATES`，再查 `trading_calendar` 真实表。对于周末（如周日 2026-08-02），第一行 `trade_date.weekday() >= 5` 立即判定为 False，零开销且 100% 准确。
+  - 调休为工作日的周末（如国庆调休周六），`weekday >= 5` 会继续查 `trading_calendar.is_trading`，若为交易日则依然严格要求非空。
+
+## Migration Plan
+
+1. 编辑 `src/cnequity/steps/common.py`：在 `fetch_incremental_daily` 中加入 `dataset in CALENDAR_DATE_DATASETS and not is_trading_day(config, d)` 的放行逻辑。
+2. 编写单元测试：
+   - 模拟自然日增量拉取包含非交易日 0 行时的通过行为；
+   - 模拟正常交易日 0 行时的抛错行为；
+   - 模拟非交易日有数据时的正常入库行为。
+3. 运行 `ruff` 检查与相关单元测试，确认全绿。

--- a/openspec/changes/announcement-calendar-empty-tolerance/proposal.md
+++ b/openspec/changes/announcement-calendar-empty-tolerance/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+`announcement_index` 在 [`src/cnequity/steps/common.py`](file:///home/bladestone/devspace/gitcode/stockagent/CNEquity/src/cnequity/steps/common.py#L68) 中被声明为日历日数据集（`CALENDAR_DATE_DATASETS = frozenset({"announcement_index", "regulatory_events"})`）。增量抓取 `fetch_incremental_daily` 会按自然日逐日拉取从 `watermark + 1` 到 `trade_date` 之间的所有日期。此设计的初衷非常明确：A 股上市公司在周末及节假日（尤其是周六）经常集中发布披露公告（例如 2026-08-01 周六全市场发布了 1,371 条公告），若仅按交易日拉取会导致周末披露静默遗失。
+
+然而，在周日（例如 2026-08-02、2026-07-26）以及法定节假日中段，全市场物理上经常**完全没有上市公司发布公告**（CNINFO 真实全集查询 `totalAnnouncement: 0`）。而 `step_announcement_index` 委托给 `run_incremental_fetched` 时未开启 `allow_empty=True`，导致 `fetch_incremental_daily` 遇到空结果时直接触发硬性非空断言：
+`RuntimeError: announcement_index: no rows returned for 2026-08-02`
+从而导致 `capital` 组直接失败，并阻塞后续依赖它的步骤（如 `sentiment_scores`）。
+
+实测探测同时证明：在**正常交易日**，A 股 5,300+ 家上市公司每天必然有大量披露（最冷清交易日也有 477~540 条，定期报告披露期单日达 6,500~22,000+ 条），交易日返回 0 行 100% 意味着上游数据源故障或反爬封禁，必须坚守 Fail-Loud 报警。因此，不能简单采用全局 `allow_empty=True`，而必须实施**交易日感知的容空策略**。
+
+## What Changes
+
+- **A. 日历日增量抓取容空（Trading-Day Sensitive Empty Tolerance）**：
+  在 `fetch_incremental_daily` 的逐日校验逻辑中，对于属于 `CALENDAR_DATE_DATASETS` 的数据集，增加非交易日感知判断：
+  - 若待抓取日期 `d` 为**非交易日（周末/法定节假日，`not is_trading_day(config, d)`）**且返回 0 行：视为合法的自然空日，跳过该日并记录日志，不抛出异常；
+  - 若 `d` 为**正常交易日（`is_trading_day(config, d)`）**且返回 0 行：严格保留现有保护机制，抛出 `RuntimeError: {dataset}: no rows returned for trading day {d}`，守住上游故障拦截底线。
+- **B. 保留非交易日有效数据入库与水印推进**：
+  非交易日若有公告（如周六的 1,371 条），照常参与 diagonal relaxed 合并并入库；若全为 0 行，则当批次保持为空，直到后续有数据的日期一同合并落库并由 `finalize` 将 watermark 正确推向最新有数据的日期。
+- **非目标**：
+  - 不修改 CNINFO 底层 adapter 的分桶与 POST 查询机制；
+  - 不修改 `regulatory_events`（其已显式传递 `allow_empty=True`，两者在日历日语义上完全自洽）；
+  - 不引入新的配置项或破坏现有交易日数据集（行情、资金流等）的严格校验契约。
+
+## Capabilities
+
+### New Capabilities
+
+- `announcement-calendar-empty-tolerance`: 规定日历日级别的信息披露数据集（`announcement_index` 等）在增量回溯过程中的空结果容忍契约：非交易日合法允许 0 行跳过，正常交易日严格禁止 0 行并大声失败（Fail Loud）。
+
+### Modified Capabilities
+
+<!-- 无既有已归档 spec 受破坏性影响 -->
+
+## Impact
+
+- **修改代码**：
+  - `src/cnequity/steps/common.py`：在 `fetch_incremental_daily` 的空结果判断中引入 `CALENDAR_DATE_DATASETS` + `not is_trading_day(config, d)` 放行逻辑。
+- **测试覆盖**：
+  - `tests/unit/test_cninfo_announcements.py` 或 `tests/unit/test_incremental_daily.py`：
+    - 验证周六有数据 + 周日无数据（0行）+ 周一有数据时，连续增量抓取能够平滑成功合并入库，不再触发 RuntimeError；
+    - 验证正常交易日若返回 0 行，依然准确抛出 `RuntimeError: announcement_index: no rows returned for ...`。
+- **无影响面**：
+  - 不改变存储结构、DuckDB 视图、Parquet 字段与元数据定义；
+  - 维持现有增量 watermark 推进语义与幂等重跑逻辑。

--- a/openspec/changes/announcement-calendar-empty-tolerance/specs/announcement-calendar-empty-tolerance/spec.md
+++ b/openspec/changes/announcement-calendar-empty-tolerance/specs/announcement-calendar-empty-tolerance/spec.md
@@ -1,0 +1,35 @@
+## Purpose
+
+Defines empty-response tolerance rules for calendar-date disclosure feeds (such as `announcement_index`), allowing zero-row responses on non-trading days while maintaining strict non-empty failure guards on trading days.
+
+## ADDED Requirements
+
+### Requirement: Non-trading calendar days tolerate zero rows in incremental fetch
+
+The system SHALL tolerate an empty (0 rows) response during daily incremental fetching of datasets configured in `CALENDAR_DATE_DATASETS` if the evaluated date is not a trading day (`is_trading_day == False`).
+
+- An empty non-trading day MUST NOT raise a `RuntimeError`.
+- An empty non-trading day MUST be safely omitted from the combined partition frames.
+- If non-empty disclosure rows exist on a non-trading day (e.g. Saturday filings), those rows MUST be retained and included in the staged partition.
+
+#### Scenario: Sunday with zero announcements
+- **WHEN** incremental fetch walks calendar date 2026-08-02 (Sunday) for `announcement_index`
+- **AND** the source returns an empty dataframe (0 rows)
+- **THEN** the system logs the occurrence and continues without raising an error
+
+#### Scenario: Saturday with valid announcements
+- **WHEN** incremental fetch walks calendar date 2026-08-01 (Saturday) for `announcement_index`
+- **AND** the source returns 1,371 rows
+- **THEN** all 1,371 rows are included in the staged partition
+
+### Requirement: Normal trading days strictly reject zero rows
+
+The system SHALL continue to enforce the strict non-empty guard on any date classified as a trading day (`is_trading_day == True`).
+
+- If the source returns zero rows for a trading day and `allow_empty` is not explicitly `True`, the system MUST raise `RuntimeError: {dataset}: no rows returned for {date}`.
+- This ensures that upstream source outages, crawler bans, or transport silent drops during trading days are loudly reported.
+
+#### Scenario: Trading day returns zero rows
+- **WHEN** incremental fetch walks a normal trading day (e.g. Monday 2026-08-03) for `announcement_index`
+- **AND** the source returns an empty dataframe (0 rows)
+- **THEN** `fetch_incremental_daily` raises `RuntimeError: announcement_index: no rows returned for 2026-08-03`

--- a/openspec/changes/announcement-calendar-empty-tolerance/tasks.md
+++ b/openspec/changes/announcement-calendar-empty-tolerance/tasks.md
@@ -1,0 +1,28 @@
+## 1. Core Incremental Logic in `src/cnequity/steps/common.py`
+
+- [x] 1.1 In `fetch_incremental_daily` ([`src/cnequity/steps/common.py`](file:///home/bladestone/devspace/gitcode/stockagent/CNEquity/src/cnequity/steps/common.py#L482)), add non-trading calendar date check to empty-response validation:
+  ```python
+  if part.is_empty():
+      if not allow_empty:
+          if dataset in CALENDAR_DATE_DATASETS and not is_trading_day(config, d):
+              logger.info(
+                  "%s: 0 rows returned for non-trading calendar date %s (tolerated)",
+                  dataset,
+                  d.isoformat(),
+              )
+              continue
+          raise RuntimeError(f"{dataset}: no rows returned for {d.isoformat()}")
+  ```
+- [x] 1.2 Verify that non-empty rows on non-trading days (e.g. Saturday filings) are unaffected and properly parsed, validated, and staged.
+
+## 2. Unit Tests in `tests/unit/test_incremental_daily.py`
+
+- [x] 2.1 Add unit test verifying that `fetch_incremental_daily` on a `CALENDAR_DATE_DATASETS` feed (e.g. `announcement_index`) successfully tolerates 0 rows when `is_trading_day` returns `False` (e.g. Sunday).
+- [x] 2.2 Add unit test verifying that `fetch_incremental_daily` on `announcement_index` still raises `RuntimeError` when a trading day returns 0 rows.
+- [x] 2.3 Add unit test verifying a multi-day span (e.g. Saturday with rows, Sunday 0 rows, Monday with rows) returns a concatenated dataframe containing the Saturday and Monday rows without errors.
+
+## 3. Verification & Code Quality
+
+- [x] 3.1 Run `ruff check` and `ruff format --check` to ensure no lint regressions.
+- [x] 3.2 Run `pytest tests/unit` to ensure all unit tests pass cleanly.
+- [x] 3.3 Verify against real CNINFO query logic for 2026-08-01 through 2026-08-03 to confirm full compatibility.

--- a/src/cnequity/steps/common.py
+++ b/src/cnequity/steps/common.py
@@ -417,6 +417,8 @@ def fetch_incremental_daily(
             )
         frame = fetch_fn(trade_date)
         if frame.is_empty() and not allow_empty:
+            if dataset in CALENDAR_DATE_DATASETS and not is_trading_day(config, trade_date):
+                return pl.DataFrame(), []
             raise RuntimeError(f"{dataset}: no rows returned for {trade_date.isoformat()}")
         _validate_trade_date(frame, dataset, trade_date, date_col=date_col)
         return frame, []
@@ -447,6 +449,13 @@ def fetch_incremental_daily(
         part = fetch_fn(d)
         if part.is_empty():
             if not allow_empty:
+                if dataset in CALENDAR_DATE_DATASETS and not is_trading_day(config, d):
+                    logger.info(
+                        "%s: 0 rows returned for non-trading calendar date %s (tolerated)",
+                        dataset,
+                        d.isoformat(),
+                    )
+                    continue
                 raise RuntimeError(f"{dataset}: no rows returned for {d.isoformat()}")
             spec = DATASETS.get(dataset)
             if spec is not None and spec.coverage_mode == "session_dense":

--- a/tests/unit/test_incremental_daily.py
+++ b/tests/unit/test_incremental_daily.py
@@ -599,3 +599,110 @@ def test_step_fund_flow_single_day_when_caught_up(tmp_path, monkeypatch):
     assert fetched == [date(2024, 6, 28)]
     assert result["rows_written"] == 1
     assert "context_updates" not in result
+
+
+def test_calendar_date_dataset_tolerates_zero_rows_on_non_trading_day(tmp_path, monkeypatch):
+    import dataclasses
+
+    cfg = Config(data_root=tmp_path / "data")
+    _seed_trading_calendar(cfg, date(2024, 6, 28), date(2024, 7, 1))
+    # 2024-06-30 is Sunday (non-trading day)
+    assert not is_trading_day(cfg, date(2024, 6, 30))
+    from cnequity.domain.datasets import DATASETS
+
+    monkeypatch.setitem(
+        DATASETS,
+        "announcement_index",
+        dataclasses.replace(DATASETS["announcement_index"], reconciliation_lookback_days=0),
+    )
+    StateStore(cfg.meta_root).set_date("announcement_index", date(2024, 6, 29))
+
+    df, findings = fetch_incremental_daily(
+        cfg,
+        "announcement_index",
+        date(2024, 6, 30),
+        lambda d: pl.DataFrame(),
+        allow_empty=False,
+        date_col="announce_date",
+    )
+    assert df.is_empty()
+    assert findings == []
+
+
+def test_calendar_date_dataset_fails_loud_on_trading_day_zero_rows(tmp_path, monkeypatch):
+    import dataclasses
+
+    cfg = Config(data_root=tmp_path / "data")
+    _seed_trading_calendar(cfg, date(2024, 6, 28), date(2024, 7, 1))
+    # 2024-06-28 is Friday (trading day)
+    assert is_trading_day(cfg, date(2024, 6, 28))
+    from cnequity.domain.datasets import DATASETS
+
+    monkeypatch.setitem(
+        DATASETS,
+        "announcement_index",
+        dataclasses.replace(DATASETS["announcement_index"], reconciliation_lookback_days=0),
+    )
+    StateStore(cfg.meta_root).set_date("announcement_index", date(2024, 6, 27))
+
+    with pytest.raises(RuntimeError, match="announcement_index: no rows returned for 2024-06-28"):
+        fetch_incremental_daily(
+            cfg,
+            "announcement_index",
+            date(2024, 6, 28),
+            lambda d: pl.DataFrame(),
+            allow_empty=False,
+            date_col="announce_date",
+        )
+
+
+def test_calendar_date_dataset_multi_day_with_weekend_empty_and_valid_rows(tmp_path, monkeypatch):
+    import dataclasses
+
+    cfg = Config(data_root=tmp_path / "data")
+    _seed_trading_calendar(cfg, date(2024, 6, 28), date(2024, 7, 1))
+    # 2024-06-28 Friday (watermark)
+    # 2024-06-29 Saturday: has rows
+    # 2024-06-30 Sunday: 0 rows (non-trading day, tolerated)
+    # 2024-07-01 Monday: has rows
+    from cnequity.domain.datasets import DATASETS
+
+    monkeypatch.setitem(
+        DATASETS,
+        "announcement_index",
+        dataclasses.replace(DATASETS["announcement_index"], reconciliation_lookback_days=0),
+    )
+    StateStore(cfg.meta_root).set_date("announcement_index", date(2024, 6, 28))
+
+    def mock_fetch(d: date) -> pl.DataFrame:
+        if d == date(2024, 6, 29):
+            return pl.DataFrame(
+                {
+                    "announcement_id": ["sat-1"],
+                    "announce_date": [d],
+                    "title": ["Saturday announcement"],
+                }
+            )
+        elif d == date(2024, 6, 30):
+            return pl.DataFrame()
+        elif d == date(2024, 7, 1):
+            return pl.DataFrame(
+                {
+                    "announcement_id": ["mon-1"],
+                    "announce_date": [d],
+                    "title": ["Monday announcement"],
+                }
+            )
+        return pl.DataFrame()
+
+    df, findings = fetch_incremental_daily(
+        cfg,
+        "announcement_index",
+        date(2024, 7, 1),
+        mock_fetch,
+        allow_empty=False,
+        date_col="announce_date",
+    )
+    assert df.height == 2
+    assert sorted(df["announcement_id"].to_list()) == ["mon-1", "sat-1"]
+    assert findings == []


### PR DESCRIPTION
## 摘要

- **问题根因**：`announcement_index` 声明于 `CALENDAR_DATE_DATASETS`，其增量拉取按自然日（逐日）进行以捕获周六等周末上市公司披露；但周日及法定节假日客观上存在全市场 0 条公告的正常物理现象（例如 2026-08-02 周日 CNINFO 全集为 0）。由于 `step_announcement_index` 未开启 `allow_empty=True`，在遇到周日 0 行时直接抛出 `RuntimeError: announcement_index: no rows returned for <date>`，导致 capital 组失败并阻塞后续依赖步骤。
- **修复方案**：在 `fetch_incremental_daily` 的非空校验中增加交易日感知逻辑。对于属于 `CALENDAR_DATE_DATASETS` 的数据集，若待抓取日期为非交易日（周末/法定节假日，`not is_trading_day(config, d)`），容忍 0 行跳过并记录日志；正常交易日（`is_trading_day(config, d) == True`）继续严格要求非空并触发 Fail-Loud 报错，守住工作日源可用性防线。
- **验证与规范**：配套补充单元测试（非交易日 0 行容忍、交易日 0 行严格抛错、跨周末多日连续混合增量合并），同步更新 `CHANGELOG.md` 及 OpenSpec 变更产物。

## 检查清单

- [x] 行为变更时补充/更新测试（`pytest tests/unit` 仍保持离线）
- [x] 用户可见变更已更新文档 / 数据集目录 / CHANGELOG
- [x] 未提交本地配置、湖数据或日志
- [x] 新增网络 I/O 放在 adapters；schema/主键在 `domain/` 中声明
