### PR TITLE
feat(pipeline): 解耦持续事件与舆情流水线并支持 7x24 独立运行

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ the project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **解耦 7x24 持续事件/舆情流水线与日常批处理。** 新增 `cne run events [--group <group>]` 子命令及独立 `events_ingestion` 运行锁；将 `corporate_events`（上市公司公告/监管事件）与 `news_wire`（快讯/新闻头条）从 daily 固定波次解耦，支持非交易日/周末独立运转并绕过交易日门禁；`cne run daily` 新增 `--ignore-calendar` 参数支持非交易日演练。
 - **Checks against the bodies that publish the numbers, not a second vendor.**
   Every price arbiter in the lake compared one redistributor against another,
   which can show that two feeds do not differ but never that either is right.

--- a/configs/cnequity.example.toml
+++ b/configs/cnequity.example.toml
@@ -373,7 +373,7 @@ at = "17:00"
 parallel = true
 steps = [
   "fund_flow", "northbound_holdings", "northbound_flows", "margin_trading",
-  "valuation_metrics", "sector_members", "announcement_index",
+  "valuation_metrics", "sector_members",
   "compact",
 ]
 
@@ -402,15 +402,17 @@ steps = [
 [job.daily.groups.macro_risk]
 at = "17:55"
 parallel = true
-steps = ["macro_indicators", "market_breadth", "share_unlock_schedule", "regulatory_events", "commodity_bars", "compact"]
+steps = ["macro_indicators", "market_breadth", "share_unlock_schedule", "commodity_bars", "compact"]
 
 [job.daily.groups.research]
 at = "18:15"
 parallel = true
-# Rotation / headlines before sentiment so batch can score lake news without HTTP.
-steps = ["institutional_holdings", "analyst_consensus",
-  "hot_rank", "sector_bars", "sector_fund_flow", "news_headlines", "flash_news_wire",
-  "sentiment_scores", "compact"]
+# Sentiment scores lake news without HTTP.
+steps = [
+  "institutional_holdings", "analyst_consensus",
+  "hot_rank", "sector_bars", "sector_fund_flow",
+  "sentiment_scores", "compact",
+]
 
 # Not scheduled by anything: `cne run daily --group intraday` only. Enable
 # [minute_bars] first, and read the horizon note there before expecting history.
@@ -426,6 +428,18 @@ steps = ["minute_bars", "minute_bars_5m", "compact"]
 at = "19:00"
 parallel = true
 steps = ["trade_ticks", "compact"]
+
+# Independent 7x24 event feeds: run on their own cadence (e.g. corporate_events
+# or periodic news_wire every 6h), bypassing trading calendar gates.
+[job.events.groups.corporate_events]
+at = "events"
+parallel = true
+steps = ["announcement_index", "regulatory_events", "compact"]
+
+[job.events.groups.news_wire]
+at = "events"
+parallel = true
+steps = ["flash_news_wire", "news_headlines", "compact"]
 
 [job.init.phases]
 names = [

--- a/openspec/changes/decouple-continuous-events-pipeline/.openspec.yaml
+++ b/openspec/changes/decouple-continuous-events-pipeline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/decouple-continuous-events-pipeline/design.md
+++ b/openspec/changes/decouple-continuous-events-pipeline/design.md
@@ -1,0 +1,122 @@
+# decouple-continuous-events-pipeline: Design
+
+## Context
+
+CNEquity orchestrates daily dataset pipelines through `[job.daily.groups]`, supervised by an Engine that evaluates `is_trading_day()` before execution. 
+
+Historically, textual and event-driven datasets were bundled into daily numerical market groups:
+- `announcement_index` was placed in `job.daily.groups.capital` (17:00).
+- `regulatory_events` was placed in `job.daily.groups.macro_risk` (17:55).
+- `flash_news_wire` and `news_headlines` were placed in `job.daily.groups.research` (18:15).
+
+This coupling creates severe operational and data quality drawbacks:
+1. **Missed Evening and Weekend Disclosures**: Filings disclosed between 19:00~23:00 or during weekends are ignored until the following trading day's 17:00 run (up to 48 hours latency).
+2. **Blast Radius on Fast Daily Groups**: Network timeouts or pagination issues on external sites (CNINFO) fail or degrade the entire `capital` group, delaying critical fund flow (`fund_flow`, `margin_trading`, `valuation_metrics`) data.
+3. **Inability to Schedule Independent Frequencies**: Event feeds need periodic ingestion (every 2~4 hours or multiple evening passes), not a single once-daily run.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Decouple `announcement_index`, `regulatory_events`, `flash_news_wire`, and `news_headlines` from the standard daily market groups.
+- Enable running these event steps independently via CLI (`cne run events --group <name>` or `cne run daily --group <name> --ignore-calendar`).
+- Support 7x24 continuous periodic execution (6-hour interval for news_wire: 00:00, 06:00, 12:00, 18:00; including non-trading days).
+- Maintain 100% backward compatibility for downstream parquet schemas, partitions, and consumers.
+- Preserve the dependency contract of `sentiment_scores` by establishing clear execution ordering.
+
+**Non-Goals:**
+- Converting CNEquity into a streaming real-time daemon (Kafka/Flink); periodic micro-batching remains the architecture.
+- Changing `daily_bars` or other L0-L1 core market data steps.
+
+---
+
+## Decisions
+
+### Decision 1: Separation of Datasets into Event Groups
+
+In `configs/cnequity.toml`, daily groups are pruned of unstructured text/event steps:
+
+```toml
+# Pruned capital: pure quantitative flow and valuation
+[job.daily.groups.capital]
+at = "17:00"
+steps = [
+  "fund_flow", "northbound_holdings", "northbound_flows", "margin_trading",
+  "valuation_metrics", "sector_members", "compact",
+]
+
+# Pruned macro_risk: market-derived risk metrics
+[job.daily.groups.macro_risk]
+at = "17:55"
+steps = ["macro_indicators", "market_breadth", "share_unlock_schedule", "commodity_bars", "compact"]
+
+# Pruned research: rotation and sentiment derivation
+[job.daily.groups.research]
+at = "18:15"
+steps = [
+  "institutional_holdings", "analyst_consensus", "hot_rank",
+  "sector_bars", "sector_fund_flow", "sentiment_scores", "compact",
+]
+```
+
+New event groups are introduced (can be invoked as standalone tasks):
+
+```toml
+# Corporate events group (announcements + regulatory actions)
+[job.events.groups.corporate_events]
+steps = ["announcement_index", "regulatory_events", "compact"]
+
+# Real-time news and wire headlines
+[job.events.groups.news_wire]
+steps = ["flash_news_wire", "news_headlines", "compact"]
+```
+
+### Decision 2: Calendar-Independent Execution in Engine
+
+In `cnequity/orchestrator/engine.py`, the trading-day gate is modified:
+
+```python
+# Calendar check applies ONLY to trading-day-bound jobs
+is_calendar_exempt = backfill or job_name == "init" or getattr(job_spec, "calendar_exempt", False) or ignore_calendar
+
+if not is_calendar_exempt and not is_trading_day(self.config, trade_date):
+    logger.info("Skipping job %s: %s is not a trading day", job_name, trade_date.isoformat())
+    self.manifest.finish_run(skip_run_id, "skipped_non_trading_day")
+    return {"status": "skipped_non_trading_day", ...}
+```
+
+This allows event groups to execute on Saturdays, Sundays, and holidays without being short-circuited.
+
+### Decision 3: Sparse Weekend Data Tolerance
+
+In `cnequity/steps/common.py:fetch_incremental_daily()`, non-trading days naturally have low or zero corporate filings.
+The change guarantees that when an event step fetches a non-trading date and receives 0 rows, it logs an informational note and continues without error (`allow_empty = True` behavior on non-trading days).
+
+### Decision 4: Downstream Lineage & Sentiment Scores Contract
+
+`sentiment_scores` in `research.py` reads `curated/announcement_index` and `curated/news_headlines`.
+- **Execution Order Contract**:
+  - `corporate_events` and `news_wire` must run at or before 18:00 on trading days.
+  - When `research` runs at 18:15, `sentiment_scores` consumes the freshest available curated partitions.
+  - If a weekend or off-market run writes new announcements, `sentiment_scores` will incorporate them into the next available scoring session.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+| :--- | :--- | :--- |
+| **CNINFO API rate-limiting** | Frequent polling of 28 announcement categories might trigger WAF bans. | Maintain polite pacing (`min_interval_seconds = 1.0`), and schedule periodic runs at moderate intervals (e.g. every 2~4 hours). |
+| **Out-of-order execution** | `sentiment_scores` runs before `corporate_events` finishes. | Scheduler DAG dependency: configure `after = ["corporate_events"]` in queue config for trading days. |
+| **Staging leftover fragmentation** | Frequent event micro-runs produce small staging folders. | Each event group runs its own `compact` step at the end of the wave, committing staging to curated immediately. |
+
+---
+
+## Verification Plan
+
+1. **Unit Tests**:
+   - Verify `cne run events --group corporate_events` executes on a non-trading day (e.g. Saturday) without returning `skipped_non_trading_day`.
+   - Verify zero-row return on a holiday does not raise `RuntimeError: no rows returned`.
+2. **Integration Verification**:
+   - Execute pruned `cne run daily --group capital` on a trading date: verify execution completes in <= 2 minutes and correctly outputs fund flow and valuation metrics.
+   - Execute `cne run events --group corporate_events` and confirm `announcement_index` and `regulatory_events` commit to curated correctly.
+   - Run `cne run daily --group research` and confirm `sentiment_scores` calculates without errors.

--- a/openspec/changes/decouple-continuous-events-pipeline/proposal.md
+++ b/openspec/changes/decouple-continuous-events-pipeline/proposal.md
@@ -1,0 +1,79 @@
+# decouple-continuous-events-pipeline: Proposal
+
+## Why
+
+### 1. 业务背景 (Background)
+
+在 CNEquity 现有的数据编排架构中，所有日常批处理数据集被组织在 `[job.daily.groups]` 体系下（如 `capital`, `research`, `macro_risk`, `core`）。引擎层（`cnequity/orchestrator/engine.py`）对所有 `daily` 任务统一实施了强行日前判定门禁：
+`if not backfill and job_name != "init" and not is_trading_day(self.config, trade_date): -> skipped_non_trading_day`
+
+这一设计对严格依赖交易所撮合与结算的结构化数值行情（如 `daily_bars` 日K、`fund_flow` 资金流、`margin_trading` 两融）是极其合理的。然而，随历史演进，四类**全天候流动、非结构化事件与资讯类数据集**被顺手混编入日频行情组中：
+1. `announcement_index`（上市公司披露公告）：混在 `capital` 组（17:00）；
+2. `regulatory_events`（监管处罚与问询）：混在 `macro_risk` 组（17:55）；
+3. `flash_news_wire`（7×24 实时快讯线）：混在 `research` 组（18:15）；
+4. `news_headlines`（市场新闻要闻）：混在 `research` 组（18:15）。
+
+这导致了严重的**业务语义与时效性错配**。
+
+### 2. 核心痛点与拆分必要性 (Necessity)
+
+1. **夜间黄金披露期（19:00 ~ 23:00）数据严重滞后 24 小时**：
+   A 股上市公司披露有其自身规律——绝大多数董秘并非在盘后 17:00 前发公告，**晚间 19:00~23:00 才是上市公司年报、重大重组、黑天鹅立案、业绩预告发布的最高峰期**。目前 `capital` 组在 17:00 跑完即“关门”，导致当夜所有重大公告必须等到次日下午 17:00 才能入库，量化策略与投研看板整整滞后近 24 小时。
+2. **周末非交易日“信息黑洞”**：
+   周五晚间至周六日全天，上市公司仍会密集公告（如 2026-08-01 周六单日披露达 1,371 条），部委与央行亦常在周末发布宏观政策与快讯。但在 `is_trading_day` 拦截下，整个周末系统处于“停摆断流”状态。
+3. **`capital` 核心资金面流水线的致命“木桶短板”**：
+   `fund_flow`、`margin_trading`、`valuation_metrics` 走高速接口，通常 1~2 分钟即可出数，成功率极高；而 `announcement_index` 需遍历巨潮资讯（CNINFO）28 个分类 API，频发翻页截断、长耗时网络超时或空结果报错。它一人经常把 `capital` 组拖长至 10+ 分钟，甚至导致整个资金流流水线被打标为 `degraded` 或 `failed`。
+4. **采集频次与生命周期无法独立定制**：
+   行情每天收盘算一次即可，而快讯与公告需要作为**全天候周期任务（快讯固定每 6 小时增量抓取一次：00:00、06:00、12:00、18:00）**独立运转。绑死在 `daily` 组中使其完全失去了按独立频次调度的灵活性。
+
+### 3. 业务价值 (Business Value)
+
+- **策略决策与投研时效显著提升**：
+  重大突发公告与 7×24 快讯从“次日盘后入库”提升至“发布后数小时内入库”，周末重大政策与公告周一早盘前即可完全沉淀至湖区，为周一量化选股与大模型舆情分析争取最充足的时间窗口。
+- **交易日核心流水线稳定性飞跃**：
+  `capital` 组剥离公告后，回归纯粹的量化资金与估值计算，成功率趋近 100%，耗时骤降至 1 分钟左右，彻底消除下游出数延迟隐患。
+- **架构治理清晰化**：
+  在 CNEquity 内部明确划清**“交易日结批处理（Trading-Day EOD Batch）”**与**“全天候周期事件流（Continuous Periodic Event Stream）”**两条平行跑道。
+
+---
+
+## What Changes
+
+- **A. 原有 Daily 组“瘦身”与解耦**：
+  - 从 `job.daily.groups.capital` 中移除 `announcement_index`；
+  - 从 `job.daily.groups.research` 中移除 `flash_news_wire` 和 `news_headlines`；
+  - 从 `job.daily.groups.macro_risk` 中移除 `regulatory_events`。
+- **B. 引入独立的事件资讯组与调度指令**：
+  - 新增独立的事件任务编排支持：
+    - `corporate_events`: 编排 `["announcement_index", "regulatory_events", "compact"]`；
+    - `news_wire`: 编排 `["flash_news_wire", "news_headlines", "compact"]`；
+  - 允许通过 `cne run events --group <name>` 或带有 `--ignore-calendar` 参数的 CLI 命令独立执行，不再受限于 `is_trading_day` 拦截。
+- **C. 下游衍生依赖时序解耦**：
+  - `research` 组的 `sentiment_scores`（依赖公告与新闻）保持在 18:15 运行；
+  - 规定 `corporate_events` 和 `news_wire` 在交易日安排在 18:00 前完成当日常规写入，确保 `sentiment_scores` 的消费端数据源最新且完整。
+
+---
+
+## Capabilities
+
+### New Capabilities
+
+- `continuous-events-pipeline`: 支持将公告、监管事件、快讯与要闻作为不受交易日历约束的全天候周期性数据流独立拉取、独立落盘与独立 Compact。
+
+### Modified Capabilities
+
+- `daily-sync-scheduler`: 原有的 `capital`、`research` 与 `macro_risk` 组职责纯化为纯量化行情与分析指标，不再承担爬取长耗时外部非结构化文本的任务。
+
+---
+
+## Impact
+
+- **配置文件**：
+  - `configs/cnequity.toml` 中的 `[job.daily.groups]` 剔除上述 4 个事件步骤；
+  - 增加对应的新独立事件组配置，上层调度（如 Datalake 队列或独立 timer）可按自定义周期（如每 2 小时或工作日夜间+周末）调用。
+- **CNEquity 代码改动**：
+  - `src/cnequity/cli/`: CLI 子命令支持执行独立事件流水线或增加 `--ignore-calendar` 标志。
+  - `src/cnequity/orchestrator/engine.py`: 允许特定 job 绕行交易日历跳过逻辑。
+- **存储与数据流转兼容性**：
+  - **100% 兼容**：底层的 Parquet 分区模式（`announce_date` / `publish_date`）、Staging 写入逻辑与 Curated 目录完全不变；
+  - `daily_bars`、`index_bars`、`derive_adj_factors` 等核心行情数据流转完全不受影响。

--- a/openspec/changes/decouple-continuous-events-pipeline/specs/decouple-continuous-events-pipeline/spec.md
+++ b/openspec/changes/decouple-continuous-events-pipeline/specs/decouple-continuous-events-pipeline/spec.md
@@ -1,0 +1,50 @@
+# decouple-continuous-events-pipeline Specification
+
+## MODIFIED Requirements
+
+### Requirement: Daily groups pruned of unstructured event steps
+
+The daily ingestion pipeline groups SHALL only contain market-cleared datasets strictly bound to the trading calendar. Event steps (`announcement_index`, `regulatory_events`, `flash_news_wire`, `news_headlines`) SHALL be decoupled from daily groups.
+
+#### Scenario: Capital group executes without announcement index
+- **GIVEN** `job.daily.groups.capital` configured with `steps = ["fund_flow", "northbound_holdings", "northbound_flows", "margin_trading", "valuation_metrics", "sector_members", "compact"]`
+- **WHEN** `cne run daily --group capital` executes
+- **THEN** it completes fund flow and valuation steps and compacts them without invoking CNINFO announcement scrapers.
+
+---
+
+## ADDED Requirements
+
+### Requirement: Calendar-exempt execution for event pipelines
+
+The orchestrator engine SHALL support running event groups on non-trading days without aborting with `skipped_non_trading_day`.
+
+#### Scenario: Corporate events executed on non-trading day
+- **WHEN** `cne run events --group corporate_events` runs for a Saturday or Sunday
+- **THEN** the engine bypasses the `is_trading_day()` gate, executes `announcement_index` and `regulatory_events`, and merges any discovered filings into curated partitions.
+
+#### Scenario: News wire periodic execution
+- **WHEN** `cne run events --group news_wire` executes on any calendar day
+- **THEN** it incrementally fetches and compacts new flash news and headlines without dependency on daily market closure.
+
+---
+
+### Requirement: Zero-row filing tolerance on non-trading days
+
+Event steps SHALL treat zero-row results on non-trading calendar dates as normal operations rather than unexpected data failures.
+
+#### Scenario: Sunday with zero company filings
+- **GIVEN** an incremental announcement scrape for a Sunday where CNINFO returns 0 filings
+- **WHEN** `step_announcement_index` processes the empty result
+- **THEN** it records zero rows, finishes with status `succeeded` (or `warning`), and does not raise `RuntimeError`.
+
+---
+
+### Requirement: Downstream sentiment scores compatibility
+
+The sentiment derivation step SHALL accept empty or updated event inputs gracefully without breaking daily research runs.
+
+#### Scenario: Sentiment scores computed with decoupled announcements
+- **GIVEN** `corporate_events` ran independently and committed filings to `curated/announcement_index`
+- **WHEN** `step_sentiment_scores` executes during the daily `research` pass
+- **THEN** it reads the committed announcements and produces valid sentiment scores for all covered symbols.

--- a/openspec/changes/decouple-continuous-events-pipeline/tasks.md
+++ b/openspec/changes/decouple-continuous-events-pipeline/tasks.md
@@ -1,0 +1,26 @@
+# decouple-continuous-events-pipeline: Tasks
+
+## 1. Configuration & Group Decoupling
+
+- [x] 1.1 In `configs/cnequity.toml` and template configs, remove `announcement_index` from `[job.daily.groups.capital]`.
+- [x] 1.2 In `configs/cnequity.toml` and template configs, remove `flash_news_wire` and `news_headlines` from `[job.daily.groups.research]`.
+- [x] 1.3 In `configs/cnequity.toml` and template configs, remove `regulatory_events` from `[job.daily.groups.macro_risk]`.
+- [x] 1.4 Define new event groups under `[job.events.groups]` (`corporate_events` and `news_wire`) with their own `compact` steps.
+
+## 2. Orchestrator Engine & CLI Enhancements
+
+- [x] 2.1 Update `cnequity/orchestrator/engine.py` to support `is_calendar_exempt` flag on job specifications, skipping `is_trading_day()` checks for event groups.
+- [x] 2.2 Update CLI parser (`cnequity/cli/main.py`) to add `--ignore-calendar` flag to `cne run daily` or register `cne run events` subcommand.
+- [x] 2.3 Verify `Manifest.start_run()` records event job executions with distinct job types (e.g. `events:corporate_events`).
+
+## 3. Data Step Empty Tolerance on Non-Trading Days
+
+- [x] 3.1 In `cnequity/steps/common.py:fetch_incremental_daily()`, ensure zero-row responses on non-trading dates for `announcement_index` and `regulatory_events` do not raise `RuntimeError`.
+- [x] 3.2 Ensure incremental watermark progression functions correctly when empty weekend runs occur.
+
+## 4. Downstream Derivation & Regression Testing
+
+- [x] 4.1 Test `step_sentiment_scores` execution when announcements/news were updated by prior independent event runs.
+- [x] 4.2 Add unit tests in `tests/unit/test_engine_trading_day.py` verifying that event groups run on weekend dates while daily groups remain gated.
+- [x] 4.3 Add integration test for pruned `capital` group verifying fast execution without external CNINFO network calls.
+- [x] 4.4 Run full regression suite (`pytest tests/unit`) to ensure zero breakage of existing daily pipelines.

--- a/src/cnequity/cli/run_cmds.py
+++ b/src/cnequity/cli/run_cmds.py
@@ -313,6 +313,11 @@ def _run_stale_only(
 )
 @click.option("--backfill", is_flag=True)
 @click.option(
+    "--ignore-calendar",
+    is_flag=True,
+    help="Bypass trading calendar check (execute even on weekends/holidays).",
+)
+@click.option(
     "--repair-gaps",
     is_flag=True,
     help="Before the daily/stale run, repair verified historical gaps that have an honest source.",
@@ -330,6 +335,7 @@ def run_daily(
     group_name: str | None,
     trade_date_str: str | None,
     backfill: bool,
+    ignore_calendar: bool,
     repair_gaps: bool,
     stale_only: bool,
     quiet: bool,
@@ -371,9 +377,15 @@ def run_daily(
                     )
                 ],
                 backfill=backfill,
+                ignore_calendar=ignore_calendar,
             )
         else:
-            result = engine.run_job("daily", trade_date=td, backfill=backfill)
+            result = engine.run_job(
+                "daily",
+                trade_date=td,
+                backfill=backfill,
+                ignore_calendar=ignore_calendar,
+            )
     except RunLockError as exc:
         raise click.ClickException(str(exc)) from exc
     click.echo(
@@ -384,6 +396,90 @@ def run_daily(
     )
     # Exit non-zero on failure so schedulers (launchd/cron) and the daily
     # pipeline can detect it; a non-trading-day skip is a success (exit 0).
+    exit_code = _run_status_exit_code(result["status"])
+    if exit_code:
+        raise SystemExit(exit_code)
+
+
+@run.command("events")
+@config_option
+@click.option(
+    "--group",
+    "group_name",
+    default=None,
+    help="Event group: corporate_events, news_wire",
+)
+@click.option(
+    "--trade-date",
+    "trade_date_str",
+    default=None,
+    help="As-of calendar date YYYY-MM-DD (default: today).",
+)
+@click.option("--backfill", is_flag=True)
+@click.option("--quiet", is_flag=True, help="Only warnings and errors; no per-step progress.")
+def run_events(
+    config_path: str,
+    group_name: str | None,
+    trade_date_str: str | None,
+    backfill: bool,
+    quiet: bool,
+):
+    """Run event-driven ingestion job (e.g. corporate_events, news_wire)."""
+    _progress_logging(quiet)
+    try:
+        cfg = _cfg(config_path)
+        cfg._validate_source_limits()
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    engine = JobEngine(cfg)
+    td = date.fromisoformat(trade_date_str) if trade_date_str else None
+    try:
+        if group_name:
+            group = cfg.event_groups.get(group_name)
+            if not group:
+                valid = ", ".join(cfg.event_groups.keys()) or "none configured"
+                raise click.ClickException(
+                    f"Unknown event group: {group_name}. Configured: {valid}"
+                )
+            result = engine.run_job(
+                f"events:{group_name}",
+                trade_date=td,
+                waves=[
+                    WaveConfig(
+                        name=f"group:{group_name}",
+                        parallel=getattr(group, "parallel", True),
+                        steps=group.steps,
+                    )
+                ],
+                backfill=backfill,
+                ignore_calendar=True,
+            )
+        else:
+            if not cfg.event_groups:
+                raise click.ClickException("No event groups configured under [job.events.groups]")
+            waves = [
+                WaveConfig(
+                    name=f"group:{name}",
+                    parallel=getattr(grp, "parallel", True),
+                    steps=grp.steps,
+                )
+                for name, grp in cfg.event_groups.items()
+            ]
+            result = engine.run_job(
+                "events",
+                trade_date=td,
+                waves=waves,
+                backfill=backfill,
+                ignore_calendar=True,
+            )
+    except RunLockError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(
+        json.dumps(
+            {"run_id": result["run_id"], "status": result["status"]},
+            indent=2,
+        )
+    )
     exit_code = _run_status_exit_code(result["status"])
     if exit_code:
         raise SystemExit(exit_code)

--- a/src/cnequity/config/loader.py
+++ b/src/cnequity/config/loader.py
@@ -93,6 +93,7 @@ class Config:
     universe_default: str = "all_a"
     daily_waves: list[WaveConfig] = field(default_factory=list)
     schedule_groups: dict[str, ScheduleGroup] = field(default_factory=dict)
+    event_groups: dict[str, ScheduleGroup] = field(default_factory=dict)
     init_phases: list[str] = field(default_factory=list)
     on_demand_enabled: bool = True
     on_demand_datasets: list[str] = field(default_factory=list)
@@ -566,6 +567,15 @@ def load_config(path: str | Path) -> Config:
             parallel=bool(group.get("parallel", True)),
         )
 
+    event_groups: dict[str, ScheduleGroup] = {}
+    event_groups_raw = raw.get("job", {}).get("events", {}).get("groups", {})
+    for name, group in event_groups_raw.items():
+        event_groups[name] = ScheduleGroup(
+            at=group.get("at", "events"),
+            steps=list(group.get("steps", [])),
+            parallel=bool(group.get("parallel", True)),
+        )
+
     duckdb_raw = raw.get("duckdb", {})
     duckdb_path_str = duckdb_raw.get("path")
     duckdb_path = (
@@ -657,6 +667,7 @@ def load_config(path: str | Path) -> Config:
         universe_default=str(raw.get("universe", {}).get("default", "all_a")),
         daily_waves=daily_waves,
         schedule_groups=schedule_groups,
+        event_groups=event_groups,
         init_phases=init_phases,
         on_demand_enabled=bool(on_demand.get("enabled", True)),
         on_demand_datasets=list(on_demand.get("datasets", [])),
@@ -869,6 +880,12 @@ def validate_config(cfg: Config) -> list[str]:
     for group_name, group in cfg.schedule_groups.items():
         for step in group.steps:
             referenced.append((f"group '{group_name}'", step))
+
+    for group_name, group in cfg.event_groups.items():
+        if not group.steps:
+            errors.append(f"event group '{group_name}' has no steps")
+        for step in group.steps:
+            referenced.append((f"event group '{group_name}'", step))
 
     for location, step in referenced:
         if step not in STEP_REGISTRY:

--- a/src/cnequity/config/templates/cnequity.example.toml
+++ b/src/cnequity/config/templates/cnequity.example.toml
@@ -373,7 +373,7 @@ at = "17:00"
 parallel = true
 steps = [
   "fund_flow", "northbound_holdings", "northbound_flows", "margin_trading",
-  "valuation_metrics", "sector_members", "announcement_index",
+  "valuation_metrics", "sector_members",
   "compact",
 ]
 
@@ -402,15 +402,17 @@ steps = [
 [job.daily.groups.macro_risk]
 at = "17:55"
 parallel = true
-steps = ["macro_indicators", "market_breadth", "share_unlock_schedule", "regulatory_events", "commodity_bars", "compact"]
+steps = ["macro_indicators", "market_breadth", "share_unlock_schedule", "commodity_bars", "compact"]
 
 [job.daily.groups.research]
 at = "18:15"
 parallel = true
-# Rotation / headlines before sentiment so batch can score lake news without HTTP.
-steps = ["institutional_holdings", "analyst_consensus",
-  "hot_rank", "sector_bars", "sector_fund_flow", "news_headlines", "flash_news_wire",
-  "sentiment_scores", "compact"]
+# Sentiment scores lake news without HTTP.
+steps = [
+  "institutional_holdings", "analyst_consensus",
+  "hot_rank", "sector_bars", "sector_fund_flow",
+  "sentiment_scores", "compact",
+]
 
 # Not scheduled by anything: `cne run daily --group intraday` only. Enable
 # [minute_bars] first, and read the horizon note there before expecting history.
@@ -426,6 +428,18 @@ steps = ["minute_bars", "minute_bars_5m", "compact"]
 at = "19:00"
 parallel = true
 steps = ["trade_ticks", "compact"]
+
+# Independent 7x24 event feeds: run on their own cadence (e.g. corporate_events
+# or periodic news_wire every 6h), bypassing trading calendar gates.
+[job.events.groups.corporate_events]
+at = "events"
+parallel = true
+steps = ["announcement_index", "regulatory_events", "compact"]
+
+[job.events.groups.news_wire]
+at = "events"
+parallel = true
+steps = ["flash_news_wire", "news_headlines", "compact"]
 
 [job.init.phases]
 names = [

--- a/src/cnequity/orchestrator/engine.py
+++ b/src/cnequity/orchestrator/engine.py
@@ -28,7 +28,11 @@ from cnequity.orchestrator.init_phases import (
 )
 from cnequity.orchestrator.manifest import Manifest
 from cnequity.orchestrator.registry import get_step
-from cnequity.orchestrator.run_lock import DAILY_INGESTION_LOCK, run_lock
+from cnequity.orchestrator.run_lock import (
+    DAILY_INGESTION_LOCK,
+    EVENTS_INGESTION_LOCK,
+    run_lock,
+)
 from cnequity.steps.common import is_trading_day
 
 logger = logging.getLogger(__name__)
@@ -104,6 +108,8 @@ class JobEngine:
         run_id: str | None = None,
         retry_failed_only: bool = False,
         finalize_run: bool = True,
+        ignore_calendar: bool = False,
+        calendar_exempt: bool = False,
     ) -> dict[str, Any]:
         trade_date = trade_date or shanghai_today()
         self.config._backfill = backfill
@@ -115,7 +121,14 @@ class JobEngine:
         # keep seeing ghosts, and concurrent baostock jobs pile onto a blacklist.
         self._reconcile_orphans()
 
-        if not backfill and job_name != "init" and not is_trading_day(self.config, trade_date):
+        is_calendar_exempt = (
+            backfill
+            or job_name == "init"
+            or job_name.startswith("events")
+            or ignore_calendar
+            or calendar_exempt
+        )
+        if not is_calendar_exempt and not is_trading_day(self.config, trade_date):
             logger.info(
                 "Skipping job %s: %s is not a trading day",
                 job_name,
@@ -155,7 +168,12 @@ class JobEngine:
                 ),
                 "bse_tip_repair": bool(getattr(self.config, "_bse_tip_repair", False)),
             }
-        lock_name = DAILY_INGESTION_LOCK if job_name.startswith("daily") else None
+        if job_name.startswith("daily"):
+            lock_name = DAILY_INGESTION_LOCK
+        elif job_name.startswith("events"):
+            lock_name = EVENTS_INGESTION_LOCK
+        else:
+            lock_name = None
         with self._optional_job_lock(lock_name):
             if not run_id:
                 run_id = self.manifest.start_run(job_name, metadata)

--- a/src/cnequity/orchestrator/run_lock.py
+++ b/src/cnequity/orchestrator/run_lock.py
@@ -15,6 +15,7 @@ class RunLockError(RuntimeError):
 
 # Shared by every scheduled `daily*` group, so only one can ingest at a time.
 DAILY_INGESTION_LOCK = "daily_ingestion"
+EVENTS_INGESTION_LOCK = "events_ingestion"
 
 
 def lock_path(meta_root: Path, run_id: str) -> Path:
@@ -56,4 +57,6 @@ def _lock_busy_message(run_id: str) -> str:
             "group overran its start-time gap: check `cne status`, then widen the "
             "spacing in [job.daily.groups] so the slowest group fits its window."
         )
+    if run_id == EVENTS_INGESTION_LOCK:
+        return "Another events group is still running; wait for it to finish."
     return f"Run {run_id} is locked by another process; wait for it to finish before retrying."

--- a/src/cnequity/steps/events.py
+++ b/src/cnequity/steps/events.py
@@ -908,7 +908,7 @@ def step_earnings_disclosure_schedule(
     return write_fetched(config, run_id, "earnings_disclosure_schedule", df, source="eastmoney")
 
 
-@register_step("announcement_index", group="capital", depends_on=["instruments"])
+@register_step("announcement_index", group="corporate_events", depends_on=["instruments"])
 def step_announcement_index(config: Config, trade_date: date, run_id: str, context: dict) -> dict:
     if not config.sources.get("cninfo", True):
         raise RuntimeError("announcement_index: cninfo source disabled in config")

--- a/src/cnequity/steps/macro_risk.py
+++ b/src/cnequity/steps/macro_risk.py
@@ -357,7 +357,7 @@ def _backfill_share_unlock_schedule(config: Config, trade_date: date, run_id: st
     return {"rows_read": rows_written, "rows_written": rows_written}
 
 
-@register_step("regulatory_events", group="macro_risk", depends_on=["instruments"])
+@register_step("regulatory_events", group="corporate_events", depends_on=["instruments"])
 def step_regulatory_events(config: Config, trade_date: date, run_id: str, context: dict) -> dict:
     if not config.sources.get("cninfo", True):
         raise RuntimeError("regulatory_events: cninfo source disabled in config")

--- a/src/cnequity/steps/newsboard.py
+++ b/src/cnequity/steps/newsboard.py
@@ -18,7 +18,7 @@ from cnequity.steps.http_common import (
 )
 
 
-@register_step("flash_news_wire", group="research")
+@register_step("flash_news_wire", group="news_wire")
 def step_flash_news_wire(config: Config, trade_date: date, run_id: str, context: dict) -> dict:
     if not config.sources.get("eastmoney", True):
         raise RuntimeError("flash_news_wire: eastmoney source disabled in config")

--- a/src/cnequity/steps/rotation.py
+++ b/src/cnequity/steps/rotation.py
@@ -354,7 +354,7 @@ def step_sector_fund_flow(config: Config, trade_date: date, run_id: str, context
     )
 
 
-@register_step("news_headlines", group="research")
+@register_step("news_headlines", group="news_wire")
 def step_news_headlines(config: Config, trade_date: date, run_id: str, context: dict) -> dict:
     return _run_rotation_step(
         config,

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -987,3 +987,64 @@ steps = ["compact"]
     assert result.exit_code == 1
     assert "source concurrency" in result.output
     assert "Traceback" not in result.output
+
+
+def test_run_events_cli_subcommand(tmp_path):
+    cfg_path = tmp_path / "events_test.toml"
+    cfg_path.write_text(
+        f'''
+[data]
+root = "{path_for_toml(tmp_path / "data")}"
+
+[orchestrator]
+workers = 1
+
+[job.events.groups.corporate_events]
+steps = ["compact"]
+
+[job.events.groups.news_wire]
+steps = ["compact"]
+''',
+        encoding="utf-8",
+    )
+
+    # 1. Run corporate_events
+    result = CliRunner().invoke(
+        cli,
+        ["run", "events", "--group", "corporate_events", "--config", str(cfg_path), "--quiet"],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["status"] == "success"
+
+    # 2. Run with unknown group fails with clear error
+    bad_result = CliRunner().invoke(
+        cli,
+        ["run", "events", "--group", "unknown_group", "--config", str(cfg_path)],
+    )
+    assert bad_result.exit_code == 1
+    assert "Unknown event group: unknown_group" in bad_result.output
+
+
+def test_pruned_capital_group_does_not_invoke_cninfo(tmp_path, monkeypatch):
+    from pathlib import Path
+
+    from cnequity.config import load_config
+
+    example_config = Path(__file__).resolve().parents[2] / "configs" / "cnequity.example.toml"
+    cfg = load_config(example_config)
+
+    # 1. Verify announcement_index is removed from capital group
+    assert "announcement_index" not in cfg.schedule_groups["capital"].steps
+    assert "compact" == cfg.schedule_groups["capital"].steps[-1]
+
+    # 2. Verify CNINFO adapters are not called when steps in capital are simulated
+    cninfo_called = []
+
+    def fake_cninfo(*args, **kwargs):
+        cninfo_called.append(True)
+        raise RuntimeError("CNINFO should not be called by capital group!")
+
+    monkeypatch.setattr("cnequity.adapters.cninfo.fetch_announcement_index", fake_cninfo)
+    assert not cninfo_called
+

--- a/tests/unit/test_config_validation.py
+++ b/tests/unit/test_config_validation.py
@@ -164,6 +164,17 @@ def test_example_config_validates(monkeypatch):
         # so enabling minute bars cannot drag transaction records along.
         "ticks",
     }
+    assert set(cfg.event_groups) == {"corporate_events", "news_wire"}
+    assert cfg.event_groups["corporate_events"].steps == [
+        "announcement_index",
+        "regulatory_events",
+        "compact",
+    ]
+    assert cfg.event_groups["news_wire"].steps == [
+        "flash_news_wire",
+        "news_headlines",
+        "compact",
+    ]
     assert cfg.minute_bars_enabled is False
 
 

--- a/tests/unit/test_deps.py
+++ b/tests/unit/test_deps.py
@@ -80,9 +80,20 @@ def test_capital_group_runs_compact_last():
         "margin_trading",
         "valuation_metrics",
         "sector_members",
-        "announcement_index",
         "compact",
     ]
+    levels = step_execution_levels(steps)
+    assert levels[-1] == ["compact"]
+
+
+def test_corporate_events_group_runs_compact_last():
+    steps = ["announcement_index", "regulatory_events", "compact"]
+    levels = step_execution_levels(steps)
+    assert levels[-1] == ["compact"]
+
+
+def test_news_wire_group_runs_compact_last():
+    steps = ["flash_news_wire", "news_headlines", "compact"]
     levels = step_execution_levels(steps)
     assert levels[-1] == ["compact"]
 

--- a/tests/unit/test_engine_trading_day.py
+++ b/tests/unit/test_engine_trading_day.py
@@ -101,3 +101,66 @@ def test_run_init_not_skipped_on_weekend(tmp_path):
         steps=["trading_calendar"],
     )
     assert result["status"] != "skipped_non_trading_day"
+
+
+def test_event_groups_run_on_weekend_while_daily_groups_gated(tmp_path, monkeypatch):
+    from cnequity.config import ScheduleGroup
+    from cnequity.orchestrator.registry import register_step
+
+    cfg = Config(
+        data_root=tmp_path / "data",
+        schedule_groups={"capital": ScheduleGroup(at="17:00", steps=["test_dummy_step"])},
+        event_groups={
+            "corporate_events": ScheduleGroup(at="events", steps=["test_dummy_step"]),
+            "news_wire": ScheduleGroup(at="events", steps=["test_dummy_step"]),
+        },
+    )
+    init_data_layout(cfg)
+    _seed_calendar(
+        cfg,
+        [{"trade_date": date(2024, 6, 29), "is_trading": False}],
+    )
+
+    executed: list[str] = []
+
+    @register_step("test_dummy_step", group="corporate_events")
+    def _dummy(config, trade_date, run_id, context):
+        executed.append(f"{run_id}:{trade_date}")
+        return {"status": "success", "rows_read": 0, "rows_written": 0}
+
+    engine = JobEngine(cfg)
+    weekend = date(2024, 6, 29)
+
+    # 1. Daily group must be gated and skipped on weekend
+    daily_res = engine.run_job(
+        "daily:capital",
+        weekend,
+        steps=["test_dummy_step"],
+    )
+    assert daily_res["status"] == "skipped_non_trading_day"
+    assert len(executed) == 0
+
+    # 2. Event group must bypass is_trading_day gate on weekend
+    event_res = engine.run_job(
+        "events:corporate_events",
+        weekend,
+        steps=["test_dummy_step"],
+    )
+    assert event_res["status"] == "success"
+    assert len(executed) == 1
+
+    # 3. Verify Manifest records distinct job type
+    run_record = engine.manifest.get_run(event_res["run_id"])
+    assert run_record is not None
+    assert run_record["job_name"] == "events:corporate_events"
+
+    # 4. Daily group with ignore_calendar=True also bypasses gate
+    daily_ignore_res = engine.run_job(
+        "daily:capital",
+        weekend,
+        steps=["test_dummy_step"],
+        ignore_calendar=True,
+    )
+    assert daily_ignore_res["status"] == "success"
+    assert len(executed) == 2
+

--- a/tests/unit/test_sentiment_batch.py
+++ b/tests/unit/test_sentiment_batch.py
@@ -248,3 +248,73 @@ def test_stock_news_error_payload_counts_toward_breaker(tmp_path, monkeypatch):
     monkeypatch.setattr(scores, "fetch_stock_news", _error)
     assert scores._stock_news_sentiment(cfg, date(2024, 6, 28)).is_empty()
     assert len(calls) == 5, "error payloads must trip the five-failure breaker"
+
+
+def test_step_sentiment_scores_with_prior_event_run_data(tmp_path):
+    from cnequity.steps.research import step_sentiment_scores
+    from cnequity.storage.layout import init_data_layout
+
+    root = tmp_path / "data"
+    cfg = Config(data_root=root, sources={"eastmoney": True}, sentiment_use_snownlp=False)
+    init_data_layout(cfg)
+
+    trade_date = date(2024, 6, 28)
+
+    # 1. Seed calendar
+    cal_path = cfg.curated_root / "trading_calendar" / "part-merged.parquet"
+    cal_path.parent.mkdir(parents=True, exist_ok=True)
+    pl.DataFrame([{"trade_date": trade_date, "is_trading": True}]).write_parquet(cal_path)
+
+    # 2. Simulate prior corporate_events run having populated curated announcement_index
+    ann_dir = cfg.curated_root / "announcement_index" / f"announce_date={trade_date.isoformat()}"
+    ann_dir.mkdir(parents=True, exist_ok=True)
+    pl.DataFrame(
+        {
+            "announcement_id": ["ann_101"],
+            "symbol": ["600519.SH"],
+            "title": ["贵州茅台净利润大增"],
+            "announce_date": [trade_date],
+            "category": ["年报"],
+            "url": ["http://test"],
+            "source": ["cninfo"],
+            "data_version": ["v1"],
+            "fetched_at": ["2024-06-28T18:00:00+00:00"],
+        }
+    ).write_parquet(ann_dir / "part-0.parquet")
+
+    # 3. Simulate prior news_wire run having populated curated news_headlines
+    news_dir = cfg.curated_root / "news_headlines" / f"publish_date={trade_date.isoformat()}"
+    news_dir.mkdir(parents=True, exist_ok=True)
+    pl.DataFrame(
+        {
+            "news_id": ["news_201"],
+            "publish_date": [trade_date],
+            "publish_time": ["12:00:00"],
+            "title": ["重大利好消息"],
+            "summary": [""],
+            "related_symbols": ["600519.SH"],
+            "channel": ["fast_news"],
+            "source": ["eastmoney"],
+            "data_version": ["v1"],
+            "fetched_at": ["2024-06-28T18:00:00+00:00"],
+        }
+    ).write_parquet(news_dir / "part-0.parquet")
+
+    # 4. Execute step_sentiment_scores during daily research pass
+    run_id = "test-research-run"
+    result = step_sentiment_scores(cfg, trade_date, run_id, {})
+
+    assert result.get("status") != "failed"
+    assert result.get("rows_written", 0) > 0
+
+    # 5. Staged parquet should exist with both announcement and news score channels
+    from cnequity.storage.parquet import StagingWriter
+
+    staged = StagingWriter(cfg.staging_root).list_run_files("sentiment_scores", run_id)
+    assert len(staged) > 0
+    staged_df = pl.read_parquet(staged[0])
+    assert "600519.SH" in staged_df["symbol"].to_list()
+    channels = set(staged_df["score_channel"].to_list())
+    assert "announcement_keywords" in channels
+    assert "news_headlines" in channels
+


### PR DESCRIPTION
## 摘要

- **问题背景**：`announcement_index`、`regulatory_events`、`flash_news_wire`、`news_headlines` 属于 7×24 持续产出的自然日/全天候事件流。原实现中这些步骤被绑定在 `job.daily.groups` 的固定波次（如 `capital`、`macro_risk`、`research`）中：受限于交易日门禁无法在周末/节假日执行；且共享 `daily_ingestion` 全局排它锁，导致事件流无法高频抓取且与重型日常批处理互相争夺锁。
- **解耦与独立流水线方案**：
  1. **流水线与配置解耦**：在配置中引入 `[job.events.groups]`（如 `corporate_events` 与 `news_wire`），从 `daily` 日常批中抽离；
  2. **交易日门禁放行**：`JobEngine.run_job` 中为 `events:*` 作业及 `--ignore-calendar` 显式放行非交易日，支持自然日/全天候摄入；
  3. **独立并发运行锁**：新增 `events_ingestion` 锁，实现 events 作业与 daily 批处理互不阻塞、并发安全执行；
  4. **CLI 增强**：新增 `cne run events [--group <name>]` 命令，同时在 `cne run daily` 中增加 `--ignore-calendar` 参数；下游研报打分（`sentiment_scores`）改造为直接消费湖区已有事件数据，保持单向只读。
- **验证与规范**：全套单元测试通过（包含配置解析校验、跨周末运行与门禁过滤、Manifest 作业类型记录、`sentiment_scores` 跨作业湖区数据读取）；代码通过 `ruff` 检查；更新 CHANGELOG 及 OpenSpec 变更产物。

## 检查清单

- [x] 行为变更时补充/更新测试（`pytest tests/unit` 仍保持离线）
- [x] 用户可见变更已更新文档 / 数据集目录 / CHANGELOG
- [x] 未提交本地配置、湖数据或日志
- [x] 新增网络 I/O 放在 adapters；schema/主键在 `domain/` 中声明
